### PR TITLE
refactor: simplify D-Bus provider and eliminate audio recorder duplic…

### DIFF
--- a/audio/ffmpeg_recorder.go
+++ b/audio/ffmpeg_recorder.go
@@ -1,11 +1,7 @@
 package audio
 
 import (
-	"context"
 	"fmt"
-	"io"
-	"os/exec"
-	"time"
 
 	"github.com/AshBuk/speak-to-ai/config"
 )
@@ -13,40 +9,41 @@ import (
 // FFmpegRecorder implements AudioRecorder using ffmpeg
 type FFmpegRecorder struct {
 	BaseRecorder
-	streamingEnabled bool
-	pipeReader       *io.PipeReader
-	pipeWriter       *io.PipeWriter
-	stdoutPipe       io.ReadCloser
 }
 
 // NewFFmpegRecorder creates a new instance of FFmpegRecorder
 func NewFFmpegRecorder(config *config.Config) *FFmpegRecorder {
 	return &FFmpegRecorder{
-		BaseRecorder:     NewBaseRecorder(config),
-		streamingEnabled: config.Audio.EnableStreaming,
+		BaseRecorder: NewBaseRecorder(config),
 	}
-}
-
-// UseStreaming indicates if this recorder supports streaming mode
-func (f *FFmpegRecorder) UseStreaming() bool {
-	return f.streamingEnabled
-}
-
-// GetAudioStream returns the audio stream for streaming mode
-func (f *FFmpegRecorder) GetAudioStream() (io.Reader, error) {
-	if !f.streamingEnabled || f.pipeReader == nil {
-		return nil, fmt.Errorf("streaming not enabled or recorder not started")
-	}
-	return f.pipeReader, nil
 }
 
 // StartRecording starts audio recording
 func (f *FFmpegRecorder) StartRecording() error {
-	// Setup streaming pipe if needed
-	if f.streamingEnabled {
-		f.pipeReader, f.pipeWriter = io.Pipe()
+	// Build ffmpeg command arguments
+	args := f.buildCommandArgs()
+
+	// Use BaseRecorder's ExecuteRecordingCommand for all process management
+	return f.ExecuteRecordingCommand("ffmpeg", args)
+}
+
+// StopRecording stops recording and returns the path to the recorded file
+func (f *FFmpegRecorder) StopRecording() (string, error) {
+	// Close streaming pipe if enabled
+	if f.streamingEnabled && f.pipeWriter != nil {
+		defer f.pipeWriter.Close()
 	}
 
+	// Stop the recording process using BaseRecorder
+	if err := f.StopProcess(); err != nil {
+		return "", err
+	}
+
+	return f.outputFile, nil
+}
+
+// buildCommandArgs builds the command arguments for ffmpeg
+func (f *FFmpegRecorder) buildCommandArgs() []string {
 	// Basic arguments
 	args := []string{
 		"-f", "alsa",
@@ -60,72 +57,12 @@ func (f *FFmpegRecorder) StartRecording() error {
 
 	// Configure output
 	if f.streamingEnabled || f.useBuffer {
-		// Output to pipe for streaming or buffer
+		// Output to stdout for streaming or buffer mode
 		args = append(args, "-f", "wav", "-")
 	} else {
 		// Output to file
 		args = append(args, f.outputFile)
 	}
 
-	// Create command but don't start it yet if we need to capture stdout
-	if f.streamingEnabled {
-		// Create context with timeout
-		f.mutex.Lock()
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-		f.ctx = ctx
-		f.cancel = cancel
-
-		// Create command with context
-		f.cmd = exec.CommandContext(f.ctx, "ffmpeg", args...)
-
-		// Get stdout pipe before starting the command
-		var err error
-		f.stdoutPipe, err = f.cmd.StdoutPipe()
-		if err != nil {
-			f.mutex.Unlock()
-			return fmt.Errorf("failed to create stdout pipe: %w", err)
-		}
-
-		// Start the command
-		if err := f.cmd.Start(); err != nil {
-			f.mutex.Unlock()
-			return fmt.Errorf("failed to start recording: %w", err)
-		}
-		f.mutex.Unlock()
-
-		// Setup goroutine to copy from stdout pipe to our pipe writer
-		go func() {
-			defer f.pipeWriter.Close()
-			buf := make([]byte, 4096)
-			for {
-				n, err := f.stdoutPipe.Read(buf)
-				if n > 0 {
-					f.pipeWriter.Write(buf[:n])
-				}
-				if err != nil {
-					break
-				}
-			}
-		}()
-
-		return nil
-	}
-
-	// For non-streaming mode, use the template method
-	return f.StartProcessTemplate("ffmpeg", args, f.useBuffer)
-}
-
-// StopRecording stops recording and returns the path to the recorded file
-func (f *FFmpegRecorder) StopRecording() (string, error) {
-	// Close pipe if streaming
-	if f.streamingEnabled && f.pipeWriter != nil {
-		defer f.pipeWriter.Close()
-	}
-
-	// Stop the recording process
-	if err := f.StopProcess(); err != nil {
-		return "", err
-	}
-
-	return f.outputFile, nil
+	return args
 }

--- a/hotkeys/dbus_provider.go
+++ b/hotkeys/dbus_provider.go
@@ -3,38 +3,34 @@ package hotkeys
 import (
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 
 	"github.com/godbus/dbus/v5"
 )
 
-// DbusKeyboardProvider implements KeyboardEventProvider using D-Bus
+// DbusKeyboardProvider implements KeyboardEventProvider using D-Bus portal
 type DbusKeyboardProvider struct {
-	config        HotkeyConfig
-	environment   EnvironmentType
-	callbacks     map[string]func() error
-	conn          *dbus.Conn
-	isListening   bool
-	stopListening chan bool
-	mutex         sync.Mutex
-	registeredIds []uint32 // Track registered hotkey IDs
+	config      HotkeyConfig
+	environment EnvironmentType
+	callbacks   map[string]func() error
+	conn        *dbus.Conn
+	isListening bool
+	mutex       sync.Mutex
 }
 
 // NewDbusKeyboardProvider creates a new D-Bus keyboard provider
 func NewDbusKeyboardProvider(config HotkeyConfig, environment EnvironmentType) *DbusKeyboardProvider {
 	return &DbusKeyboardProvider{
-		config:        config,
-		environment:   environment,
-		callbacks:     make(map[string]func() error),
-		isListening:   false,
-		stopListening: make(chan bool),
-		registeredIds: make([]uint32, 0),
+		config:      config,
+		environment: environment,
+		callbacks:   make(map[string]func() error),
+		isListening: false,
 	}
 }
 
-// IsSupported checks if D-Bus hotkey registration is supported
+// IsSupported checks if D-Bus portal GlobalShortcuts is available
 func (p *DbusKeyboardProvider) IsSupported() bool {
-	// Try to connect to session bus
 	conn, err := dbus.ConnectSessionBus()
 	if err != nil {
 		log.Printf("D-Bus session bus not available: %v", err)
@@ -42,48 +38,34 @@ func (p *DbusKeyboardProvider) IsSupported() bool {
 	}
 	defer conn.Close()
 
-	// Check if GNOME Shell is available (supports global hotkeys)
-	if p.checkGnomeShell(conn) {
-		log.Println("GNOME Shell detected - D-Bus hotkeys supported")
+	// Check if GlobalShortcuts portal is available
+	obj := conn.Object("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop")
+	call := obj.Call("org.freedesktop.DBus.Introspectable.Introspect", 0)
+	if call.Err != nil {
+		log.Printf("D-Bus portal not available: %v", call.Err)
+		return false
+	}
+
+	// Check if the introspection contains GlobalShortcuts interface
+	var introspectData string
+	if err := call.Store(&introspectData); err != nil {
+		log.Printf("Failed to get introspection data: %v", err)
+		return false
+	}
+
+	// Check for GlobalShortcuts interface in introspection data
+	if len(introspectData) > 0 && containsGlobalShortcuts(introspectData) {
+		log.Println("D-Bus portal GlobalShortcuts detected")
 		return true
 	}
 
-	// Check if KDE Plasma is available
-	if p.checkKDEPlasma(conn) {
-		log.Println("KDE Plasma detected - D-Bus hotkeys supported")
-		return true
-	}
-
-	// Check if other desktop environments support global hotkeys
-	if p.checkGenericHotkeySupport(conn) {
-		log.Println("Generic D-Bus hotkey support detected")
-		return true
-	}
-
-	log.Println("No D-Bus hotkey support detected")
+	log.Println("D-Bus portal GlobalShortcuts not available")
 	return false
 }
 
-// checkGnomeShell checks if GNOME Shell is available
-func (p *DbusKeyboardProvider) checkGnomeShell(conn *dbus.Conn) bool {
-	obj := conn.Object("org.gnome.Shell", "/org/gnome/Shell")
-	call := obj.Call("org.freedesktop.DBus.Introspectable.Introspect", 0)
-	return call.Err == nil
-}
-
-// checkKDEPlasma checks if KDE Plasma is available
-func (p *DbusKeyboardProvider) checkKDEPlasma(conn *dbus.Conn) bool {
-	obj := conn.Object("org.kde.kglobalaccel", "/kglobalaccel")
-	call := obj.Call("org.freedesktop.DBus.Introspectable.Introspect", 0)
-	return call.Err == nil
-}
-
-// checkGenericHotkeySupport checks for generic hotkey support
-func (p *DbusKeyboardProvider) checkGenericHotkeySupport(conn *dbus.Conn) bool {
-	// Check for freedesktop.org standard hotkey service
-	obj := conn.Object("org.freedesktop.impl.portal.desktop.gtk", "/org/freedesktop/portal/desktop")
-	call := obj.Call("org.freedesktop.DBus.Introspectable.Introspect", 0)
-	return call.Err == nil
+// containsGlobalShortcuts checks if the introspection data contains GlobalShortcuts interface
+func containsGlobalShortcuts(data string) bool {
+	return strings.Contains(data, "GlobalShortcuts")
 }
 
 // Start begins listening for D-Bus hotkey events
@@ -98,21 +80,13 @@ func (p *DbusKeyboardProvider) Start() error {
 	var err error
 	p.conn, err = dbus.ConnectSessionBus()
 	if err != nil {
-		return fmt.Errorf("failed to connect to session bus: %w", err)
+		return fmt.Errorf("failed to connect to session bus (D-Bus unavailable): %w", err)
 	}
 
-	// Register hotkeys based on desktop environment
-	if p.checkGnomeShell(p.conn) {
-		err = p.registerGnomeHotkeys()
-	} else if p.checkKDEPlasma(p.conn) {
-		err = p.registerKDEHotkeys()
-	} else {
-		err = p.registerGenericHotkeys()
-	}
-
-	if err != nil {
+	// Register hotkeys using GlobalShortcuts portal
+	if err := p.registerHotkeys(); err != nil {
 		p.conn.Close()
-		return fmt.Errorf("failed to register hotkeys: %w", err)
+		return fmt.Errorf("failed to register hotkeys (GlobalShortcuts portal unavailable): %w", err)
 	}
 
 	p.isListening = true
@@ -128,9 +102,6 @@ func (p *DbusKeyboardProvider) Stop() {
 	if !p.isListening {
 		return
 	}
-
-	// Unregister all hotkeys
-	p.unregisterAllHotkeys()
 
 	if p.conn != nil {
 		p.conn.Close()
@@ -155,219 +126,55 @@ func (p *DbusKeyboardProvider) RegisterHotkey(hotkey string, callback func() err
 	return nil
 }
 
-// registerGnomeHotkeys registers hotkeys for GNOME Shell
-func (p *DbusKeyboardProvider) registerGnomeHotkeys() error {
-	obj := p.conn.Object("org.gnome.Shell", "/org/gnome/Shell")
-
-	for hotkey, callback := range p.callbacks {
-		// Convert hotkey format to GNOME format
-		gnomeHotkey := p.convertToGnomeFormat(hotkey)
-
-		// Register the hotkey
-		call := obj.Call("org.gnome.Shell.Eval", 0, fmt.Sprintf(`
-			Main.wm.addKeybinding('%s', new Gio.Settings(), Meta.KeyBindingFlags.NONE, 
-				Shell.ActionMode.NORMAL, function() {
-					imports.dbus.session.emit_signal(null, '/org/freedesktop/speak_to_ai', 
-						'org.freedesktop.speak_to_ai', 'HotkeyPressed', 
-						new GLib.Variant('(s)', ['%s']));
-				});
-		`, gnomeHotkey, hotkey))
-
-		if call.Err != nil {
-			return fmt.Errorf("failed to register GNOME hotkey %s: %w", hotkey, call.Err)
-		}
-
-		// Store callback for later use
-		go p.listenForHotkeySignal(hotkey, callback)
-	}
-
-	return nil
-}
-
-// registerKDEHotkeys registers hotkeys for KDE Plasma
-func (p *DbusKeyboardProvider) registerKDEHotkeys() error {
-	obj := p.conn.Object("org.kde.kglobalaccel", "/kglobalaccel")
-
-	for hotkey, callback := range p.callbacks {
-		// Convert hotkey format to KDE format
-		kdeHotkey := p.convertToKDEFormat(hotkey)
-
-		// Register the hotkey
-		call := obj.Call("org.kde.KGlobalAccel.setShortcut", 0,
-			"speak-to-ai", hotkey, kdeHotkey, "speak-to-ai", hotkey, 0)
-
-		if call.Err != nil {
-			return fmt.Errorf("failed to register KDE hotkey %s: %w", hotkey, call.Err)
-		}
-
-		// Store callback for later use
-		go p.listenForHotkeySignal(hotkey, callback)
-	}
-
-	return nil
-}
-
-// registerGenericHotkeys registers hotkeys using generic D-Bus methods
-func (p *DbusKeyboardProvider) registerGenericHotkeys() error {
-	// Use freedesktop.org portal for generic hotkey support
+// registerHotkeys registers all hotkeys using the GlobalShortcuts portal
+func (p *DbusKeyboardProvider) registerHotkeys() error {
 	obj := p.conn.Object("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop")
 
 	for hotkey, callback := range p.callbacks {
-		// Register via portal
+		// Create shortcut options
+		options := map[string]dbus.Variant{
+			"description": dbus.MakeVariant(fmt.Sprintf("Speak-to-AI hotkey: %s", hotkey)),
+		}
+
+		// Register the shortcut
 		call := obj.Call("org.freedesktop.portal.GlobalShortcuts.CreateShortcut", 0,
-			map[string]interface{}{
-				"shortcut_id": hotkey,
-				"description": fmt.Sprintf("Speak-to-AI hotkey: %s", hotkey),
-			})
+			"",     // parent_window (empty for no parent)
+			hotkey, // shortcut_id
+			hotkey, // shortcut
+			options)
 
 		if call.Err != nil {
-			log.Printf("Warning: failed to register generic hotkey %s: %v", hotkey, call.Err)
+			log.Printf("Warning: failed to register hotkey %s: %v", hotkey, call.Err)
 			continue
 		}
 
-		// Store callback for later use
-		go p.listenForHotkeySignal(hotkey, callback)
+		// Start listening for this shortcut
+		go p.listenForShortcut(hotkey, callback)
 	}
 
 	return nil
 }
 
-// listenForHotkeySignal listens for hotkey activation signals
-func (p *DbusKeyboardProvider) listenForHotkeySignal(hotkey string, callback func() error) {
-	// Add match rule for the signal
-	rule := fmt.Sprintf("type='signal',interface='org.freedesktop.speak_to_ai',member='HotkeyPressed',path='/org/freedesktop/speak_to_ai'")
+// listenForShortcut listens for a specific shortcut activation
+func (p *DbusKeyboardProvider) listenForShortcut(shortcut string, callback func() error) {
+	// Add signal match rule
+	rule := "type='signal',interface='org.freedesktop.portal.GlobalShortcuts',member='Activated',path='/org/freedesktop/portal/desktop'"
 	p.conn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, rule)
 
 	// Listen for signals
 	c := make(chan *dbus.Signal, 10)
 	p.conn.Signal(c)
 
-	go func() {
-		for {
-			select {
-			case sig := <-c:
-				if sig.Name == "org.freedesktop.speak_to_ai.HotkeyPressed" {
-					if len(sig.Body) > 0 {
-						if pressedHotkey, ok := sig.Body[0].(string); ok && pressedHotkey == hotkey {
-							if err := callback(); err != nil {
-								log.Printf("Error executing hotkey callback for %s: %v", hotkey, err)
-							}
-						}
+	for sig := range c {
+		if sig.Name == "org.freedesktop.portal.GlobalShortcuts.Activated" {
+			if len(sig.Body) > 0 {
+				if activatedShortcut, ok := sig.Body[0].(string); ok && activatedShortcut == shortcut {
+					log.Printf("Hotkey activated: %s", shortcut)
+					if err := callback(); err != nil {
+						log.Printf("Error executing hotkey callback: %v", err)
 					}
 				}
-			case <-p.stopListening:
-				return
 			}
 		}
-	}()
-}
-
-// convertToGnomeFormat converts hotkey string to GNOME format
-func (p *DbusKeyboardProvider) convertToGnomeFormat(hotkey string) string {
-	// Convert from our format to GNOME format
-	// Example: "ctrl+shift+c" -> "<Control><Shift>c"
-	combo := ParseHotkey(hotkey)
-	result := ""
-
-	for _, mod := range combo.Modifiers {
-		switch mod {
-		case "ctrl":
-			result += "<Control>"
-		case "alt":
-			result += "<Alt>"
-		case "shift":
-			result += "<Shift>"
-		case "super", "meta", "win":
-			result += "<Super>"
-		case "altgr":
-			result += "<Mod5>"
-		}
-	}
-
-	result += combo.Key
-	return result
-}
-
-// convertToKDEFormat converts hotkey string to KDE format
-func (p *DbusKeyboardProvider) convertToKDEFormat(hotkey string) string {
-	// Convert from our format to KDE format
-	// Example: "ctrl+shift+c" -> "Ctrl+Shift+C"
-	combo := ParseHotkey(hotkey)
-	result := ""
-
-	for i, mod := range combo.Modifiers {
-		if i > 0 {
-			result += "+"
-		}
-		switch mod {
-		case "ctrl":
-			result += "Ctrl"
-		case "alt":
-			result += "Alt"
-		case "shift":
-			result += "Shift"
-		case "super", "meta", "win":
-			result += "Meta"
-		case "altgr":
-			result += "AltGr"
-		}
-	}
-
-	if len(combo.Modifiers) > 0 {
-		result += "+"
-	}
-	result += combo.Key
-	return result
-}
-
-// unregisterAllHotkeys unregisters all registered hotkeys
-func (p *DbusKeyboardProvider) unregisterAllHotkeys() {
-	if p.conn == nil {
-		return
-	}
-
-	// Signal all listeners to stop
-	close(p.stopListening)
-	p.stopListening = make(chan bool)
-
-	// Unregister based on desktop environment
-	if p.checkGnomeShell(p.conn) {
-		p.unregisterGnomeHotkeys()
-	} else if p.checkKDEPlasma(p.conn) {
-		p.unregisterKDEHotkeys()
-	} else {
-		p.unregisterGenericHotkeys()
-	}
-
-	p.registeredIds = p.registeredIds[:0]
-}
-
-// unregisterGnomeHotkeys unregisters GNOME hotkeys
-func (p *DbusKeyboardProvider) unregisterGnomeHotkeys() {
-	obj := p.conn.Object("org.gnome.Shell", "/org/gnome/Shell")
-
-	for hotkey := range p.callbacks {
-		gnomeHotkey := p.convertToGnomeFormat(hotkey)
-		obj.Call("org.gnome.Shell.Eval", 0, fmt.Sprintf(`
-			Main.wm.removeKeybinding('%s');
-		`, gnomeHotkey))
-	}
-}
-
-// unregisterKDEHotkeys unregisters KDE hotkeys
-func (p *DbusKeyboardProvider) unregisterKDEHotkeys() {
-	obj := p.conn.Object("org.kde.kglobalaccel", "/kglobalaccel")
-
-	for hotkey := range p.callbacks {
-		obj.Call("org.kde.KGlobalAccel.unregister", 0, "speak-to-ai", hotkey)
-	}
-}
-
-// unregisterGenericHotkeys unregisters generic hotkeys
-func (p *DbusKeyboardProvider) unregisterGenericHotkeys() {
-	obj := p.conn.Object("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop")
-
-	for hotkey := range p.callbacks {
-		obj.Call("org.freedesktop.portal.GlobalShortcuts.DeleteShortcut", 0, hotkey)
 	}
 }


### PR DESCRIPTION
…ation

- Simplify D-Bus provider to use only org.freedesktop.portal.GlobalShortcuts
- Remove all DE-specific code (GNOME Shell Eval, KDE-specific calls)
- Add graceful fallback when D-Bus is unavailable
- Extract common audio logic to BaseRecorder
- Move streaming functionality to BaseRecorder
- Simplify ArecordRecorder and FFmpegRecorder