### PR TITLE
feat: add MIT license headers to all Go source files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
             fi
           fi
 
+      - name: License header check
+        run: ./scripts/check-license-headers.sh
+
       - name: Build whisper.cpp libs
         run: make whisper-libs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to Speak-to-AI
+
+Thank you for your interest in contributing to Speak-to-AI! This document provides guidelines for contributing to the project.
+
+## 🤝 Code of Conduct
+
+- Be respectful and inclusive
+- Focus on constructive feedback
+- Help others learn and grow
+- Maintain a welcoming environment
+
+## 🚀 Getting Started
+
+1. Fork the repository
+2. Clone your fork: `git clone https://github.com/YOUR-USERNAME/speak-to-ai.git`
+3. Follow the development setup in [DEVELOPMENT.md](DEVELOPMENT.md)
+
+4. **Dev Workflow**
+   1. Create a feature branch: `git checkout -b feature/your-feature-name`
+   2. Make your changes
+   3. Add license headers to new Go files
+   ```go
+   // Copyright (c) 2025 Asher Buk
+   // SPDX-License-Identifier: MIT
+   ```
+   4. Commit with clear message
+   5. Push and create a Pull Request
+
+5. **Code Style**
+
+- **Formatting:** All Go code must be formatted with `gofmt` — run `make fmt`
+- **Linting:** Code must pass `golangci-lint` checks — run `make lint`
+- **Testing:** New features should include appropriate tests — run `make test`
+- **Build:** Changes must not break the build process — run `make build`
+
+**Note:** Our CI automatically validates:
+- Lint rules (`golangci-lint`)
+- Code formatting (`gofmt`) 
+- Build process
+- Unit tests
+- License headers in all Go files
+
+PRs must pass all checks before merge.
+
+## 🐛 Bug Reports
+
+When reporting bugs, include:
+
+- Create an issue
+- Operating system and version
+- Desktop environment (GNOME, KDE, etc.)
+- Display server (X11/Wayland)
+- Steps to reproduce
+- Expected vs actual behavior
+- Relevant logs
+
+## 💡 Feature Requests
+
+For new features:
+
+- Check existing issues first
+- Describe the use case
+- Consider backwards compatibility
+- Be specific about the desired behavior
+
+## 📜 License
+
+By contributing, you agree that your contributions will be licensed under the MIT License. All contributed code becomes part of the project under the same license terms.

--- a/audio/arecord_recorder.go
+++ b/audio/arecord_recorder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package audio
 
 import (

--- a/audio/arecord_recorder_test.go
+++ b/audio/arecord_recorder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package audio
 
 import (

--- a/audio/base_recorder.go
+++ b/audio/base_recorder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package audio
 
 import (

--- a/audio/chunk_processor.go
+++ b/audio/chunk_processor.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package audio
 
 import (

--- a/audio/chunk_processor_test.go
+++ b/audio/chunk_processor_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package audio
 
 import (

--- a/audio/factory.go
+++ b/audio/factory.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package audio
 
 import (

--- a/audio/factory_test.go
+++ b/audio/factory_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package audio
 
 import (

--- a/audio/ffmpeg_recorder.go
+++ b/audio/ffmpeg_recorder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package audio
 
 import (

--- a/audio/ffmpeg_recorder_test.go
+++ b/audio/ffmpeg_recorder_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package audio
 
 import (

--- a/audio/interface.go
+++ b/audio/interface.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package audio
 
 import (

--- a/audio/interface_validation_test.go
+++ b/audio/interface_validation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package audio
 
 import (

--- a/audio/mock_recorder.go
+++ b/audio/mock_recorder.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package audio
 
 import (

--- a/audio/tempfile_manager.go
+++ b/audio/tempfile_manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package audio
 
 import (

--- a/audio/tempfile_manager_test.go
+++ b/audio/tempfile_manager_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package audio
 
 import (

--- a/audio/vad.go
+++ b/audio/vad.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package audio
 
 import (

--- a/audio/vad_test.go
+++ b/audio/vad_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package audio
 
 import (

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/config/constants.go
+++ b/config/constants.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package config
 
 // Output mode constants to avoid magic strings throughout the codebase

--- a/config/default_config.go
+++ b/config/default_config.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package config
 
 // SetDefaultConfig sets default values

--- a/config/loader.go
+++ b/config/loader.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/config/security.go
+++ b/config/security.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/config/security_test.go
+++ b/config/security_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/config/validator.go
+++ b/config/validator.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/config/validator_test.go
+++ b/config/validator_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/docs.go
+++ b/docs.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 // Package speaktoai provides a high-level overview of the Speak-to-AI project.
 //
 // Speak-to-AI is a minimalist, privacy-focused desktop daemon written in Go

--- a/hotkeys/adapter.go
+++ b/hotkeys/adapter.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package hotkeys
 
 // HotkeyConfig defines the interface that a configuration must implement

--- a/hotkeys/adapter_test.go
+++ b/hotkeys/adapter_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package hotkeys
 
 import (

--- a/hotkeys/altgr_integration_test.go
+++ b/hotkeys/altgr_integration_test.go
@@ -1,5 +1,8 @@
 //go:build linux
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package hotkeys
 
 import (

--- a/hotkeys/dbus_accelerator_test.go
+++ b/hotkeys/dbus_accelerator_test.go
@@ -1,5 +1,8 @@
 //go:build linux
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package hotkeys
 
 import (

--- a/hotkeys/dbus_provider.go
+++ b/hotkeys/dbus_provider.go
@@ -1,5 +1,8 @@
 //go:build linux
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package hotkeys
 
 import (

--- a/hotkeys/dbus_provider_test.go
+++ b/hotkeys/dbus_provider_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package hotkeys
 
 import (

--- a/hotkeys/dummy_provider.go
+++ b/hotkeys/dummy_provider.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package hotkeys
 
 import (

--- a/hotkeys/dummy_provider_test.go
+++ b/hotkeys/dummy_provider_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package hotkeys
 
 import (

--- a/hotkeys/evdev_provider.go
+++ b/hotkeys/evdev_provider.go
@@ -1,5 +1,8 @@
 //go:build linux
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package hotkeys
 
 import (

--- a/hotkeys/evdev_provider_test.go
+++ b/hotkeys/evdev_provider_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package hotkeys
 
 import (

--- a/hotkeys/factory_test.go
+++ b/hotkeys/factory_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package hotkeys
 
 import (

--- a/hotkeys/interface.go
+++ b/hotkeys/interface.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package hotkeys
 
 // KeyboardEventProvider defines an interface for keyboard event sources

--- a/hotkeys/manager.go
+++ b/hotkeys/manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package hotkeys
 
 import (

--- a/hotkeys/manager_extended_test.go
+++ b/hotkeys/manager_extended_test.go
@@ -1,5 +1,8 @@
 //go:build linux
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package hotkeys
 
 import (

--- a/hotkeys/manager_linux.go
+++ b/hotkeys/manager_linux.go
@@ -1,5 +1,8 @@
 //go:build linux
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package hotkeys
 
 import "log"

--- a/hotkeys/manager_stub.go
+++ b/hotkeys/manager_stub.go
@@ -1,5 +1,8 @@
 //go:build !linux
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package hotkeys
 
 // selectProviderForEnvironment returns a dummy provider on non-Linux to avoid pulling linux deps

--- a/hotkeys/manager_test.go
+++ b/hotkeys/manager_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package hotkeys
 
 import (

--- a/hotkeys/mock_provider.go
+++ b/hotkeys/mock_provider.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package hotkeys
 
 import (

--- a/hotkeys/mock_provider_extended_test.go
+++ b/hotkeys/mock_provider_extended_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package hotkeys
 
 import (

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package app
 
 import (

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package app
 
 import (

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package app
 
 // This file contains the main entry points for handlers.

--- a/internal/app/handlers_config.go
+++ b/internal/app/handlers_config.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package app
 
 import (

--- a/internal/app/handlers_hotkeys.go
+++ b/internal/app/handlers_hotkeys.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package app
 
 import (

--- a/internal/app/handlers_recording.go
+++ b/internal/app/handlers_recording.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package app
 
 import (

--- a/internal/app/handlers_streaming.go
+++ b/internal/app/handlers_streaming.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package app
 
 import (

--- a/internal/app/handlers_vad.go
+++ b/internal/app/handlers_vad.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package app
 
 import (

--- a/internal/app/initialization.go
+++ b/internal/app/initialization.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package app
 
 import (

--- a/internal/app/output_routing_test.go
+++ b/internal/app/output_routing_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package app
 
 import (

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package app
 
 // RunAndWait starts all components and waits for shutdown signal

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package logger
 
 import (

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package logger
 
 import (

--- a/internal/notify/notification.go
+++ b/internal/notify/notification.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package notify
 
 import (

--- a/internal/notify/notification_test.go
+++ b/internal/notify/notification_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package notify
 
 import (

--- a/internal/platform/environment.go
+++ b/internal/platform/environment.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package platform
 
 import (

--- a/internal/platform/environment_test.go
+++ b/internal/platform/environment_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package platform
 
 import (

--- a/internal/tray/default_manager.go
+++ b/internal/tray/default_manager.go
@@ -1,5 +1,8 @@
 //go:build !systray
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package tray
 
 import "github.com/AshBuk/speak-to-ai/config"

--- a/internal/tray/default_systray.go
+++ b/internal/tray/default_systray.go
@@ -1,5 +1,8 @@
 //go:build systray
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package tray
 
 import "github.com/AshBuk/speak-to-ai/config"

--- a/internal/tray/icons.go
+++ b/internal/tray/icons.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package tray
 
 import (

--- a/internal/tray/interface.go
+++ b/internal/tray/interface.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package tray
 
 import "github.com/AshBuk/speak-to-ai/config"

--- a/internal/tray/mock_tray.go
+++ b/internal/tray/mock_tray.go
@@ -1,5 +1,8 @@
 //go:build !systray
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package tray
 
 import (

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -1,5 +1,8 @@
 //go:build systray
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package tray
 
 import (

--- a/internal/utils/disk_linux.go
+++ b/internal/utils/disk_linux.go
@@ -1,5 +1,8 @@
 //go:build linux
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package utils
 
 import (

--- a/internal/utils/disk_stub.go
+++ b/internal/utils/disk_stub.go
@@ -1,5 +1,8 @@
 //go:build !linux
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package utils
 
 // CheckDiskSpace is a no-op on non-Linux platforms

--- a/internal/utils/files.go
+++ b/internal/utils/files.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package utils
 
 import (

--- a/output/clipboard_outputter.go
+++ b/output/clipboard_outputter.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/output/clipboard_outputter_test.go
+++ b/output/clipboard_outputter_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/output/combined_outputter.go
+++ b/output/combined_outputter.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/output/combined_outputter_test.go
+++ b/output/combined_outputter_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/output/factory.go
+++ b/output/factory.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/output/factory_enhanced_test.go
+++ b/output/factory_enhanced_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/output/factory_test.go
+++ b/output/factory_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/output/interface.go
+++ b/output/interface.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package output
 
 // Outputter defines the interface for text output operations

--- a/output/mock_outputter.go
+++ b/output/mock_outputter.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/output/type_outputter.go
+++ b/output/type_outputter.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/output/type_outputter_test.go
+++ b/output/type_outputter_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/output/wayland_support_test.go
+++ b/output/wayland_support_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/scripts/check-license-headers.sh
+++ b/scripts/check-license-headers.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# License header validation script
+# Checks that all Go files have proper MIT license headers
+
+set -e
+
+echo "🔍 Checking license headers in Go files..."
+
+# Expected patterns
+EXPECTED_COPYRIGHT="Copyright (c) 2025 Asher Buk"
+EXPECTED_SPDX="SPDX-License-Identifier: MIT"
+
+# Find and check files
+missing_files=0
+total_files=0
+
+for file in $(find . -name "*.go" -not -path "./vendor/*" -not -path "./.git/*"); do
+    total_files=$((total_files + 1))
+    
+    # Check if both copyright and SPDX are present in first 10 lines
+    if ! head -10 "$file" | grep -q "$EXPECTED_COPYRIGHT"; then
+        echo "❌ Missing copyright: $file"
+        missing_files=$((missing_files + 1))
+    elif ! head -10 "$file" | grep -q "$EXPECTED_SPDX"; then
+        echo "❌ Missing SPDX license: $file"  
+        missing_files=$((missing_files + 1))
+    fi
+done
+
+echo "📊 Processed $total_files Go files"
+
+if [ $missing_files -eq 0 ]; then
+    echo "✅ All Go files have valid MIT license headers!"
+    exit 0
+else
+    echo "❌ Found $missing_files files with missing or invalid license headers"
+    echo ""
+    echo "Expected header format:"
+    echo "  // Copyright (c) 2025 Asher Buk"
+    echo "  // SPDX-License-Identifier: MIT"
+    exit 1
+fi

--- a/tests/integration/audio_integration_test.go
+++ b/tests/integration/audio_integration_test.go
@@ -1,6 +1,9 @@
 //go:build integration
 // +build integration
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package integration
 
 import (

--- a/tests/integration/doc.go
+++ b/tests/integration/doc.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 // Package integration contains integration tests that are built with the
 // "integration" build tag. This file intentionally has no build tags so that
 // editors and tools can resolve the package even when the tag isn't enabled.

--- a/tests/integration/end_to_end_test.go
+++ b/tests/integration/end_to_end_test.go
@@ -1,6 +1,9 @@
 //go:build integration
 // +build integration
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package integration
 
 import (

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1,6 +1,9 @@
 //go:build integration
 // +build integration
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package integration
 
 import (

--- a/tests/integration/platform_integration_test.go
+++ b/tests/integration/platform_integration_test.go
@@ -1,6 +1,9 @@
 //go:build integration
 // +build integration
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package integration
 
 import (

--- a/tests/mocks/logger.go
+++ b/tests/mocks/logger.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package mocks
 
 import "fmt"

--- a/websocket/authentication.go
+++ b/websocket/authentication.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package websocket
 
 import (

--- a/websocket/message_handler.go
+++ b/websocket/message_handler.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package websocket
 
 import (

--- a/websocket/retry_manager.go
+++ b/websocket/retry_manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package websocket
 
 import (

--- a/websocket/server.go
+++ b/websocket/server.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package websocket
 
 import (

--- a/websocket/server_test.go
+++ b/websocket/server_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package websocket
 
 import (

--- a/whisper/engine.go
+++ b/whisper/engine.go
@@ -1,5 +1,8 @@
 //go:build cgo
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package whisper
 
 import (

--- a/whisper/engine_stub.go
+++ b/whisper/engine_stub.go
@@ -1,5 +1,8 @@
 //go:build !cgo || nocgo
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package whisper
 
 import (

--- a/whisper/engine_test.go
+++ b/whisper/engine_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package whisper
 
 import (

--- a/whisper/model_manager.go
+++ b/whisper/model_manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package whisper
 
 import (

--- a/whisper/streaming_engine.go
+++ b/whisper/streaming_engine.go
@@ -1,5 +1,8 @@
 //go:build cgo
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package whisper
 
 import (

--- a/whisper/streaming_engine_stub.go
+++ b/whisper/streaming_engine_stub.go
@@ -1,5 +1,8 @@
 //go:build !cgo || nocgo
 
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
 package whisper
 
 import (


### PR DESCRIPTION
Add copyright and SPDX license identifier headers to all 100 Go files in the codebase for proper legal attribution and compliance.

- Headers follow Go community conventions using // comments
- Proper placement after build constraints where applicable
- Consistent format: Copyright (c) 2025 Asher Buk + MIT SPDX identifier
- Full coverage across all packages and test files