### PR TITLE
[DRAFT] Legacy CPU support for Intel/AMD pre-2011 (AVX-free builds)

### DIFF
--- a/docker/Dockerfile.appimage
+++ b/docker/Dockerfile.appimage
@@ -66,6 +66,10 @@ ENV APP_VERSION=${APP_VERSION}
 ARG WHISPER_CPP_REF=v1.7.6
 ENV WHISPER_CPP_REF=${WHISPER_CPP_REF}
 
+# Legacy build flag for older CPUs
+ARG LEGACY_BUILD=0
+ENV LEGACY_BUILD=${LEGACY_BUILD}
+
 # Build AppImage at image build time so docker build can produce artifacts
 RUN /usr/local/bin/build-appimage.sh
 


### PR DESCRIPTION
  ### Affected CPUs:
  - Intel Core 2 series and earlier
  - Intel Core i3/i5/i7 1st generation (Nehalem, Westmere)
  - AMD Phenom series and earlier
  - AMD FX series (some models)

### Build process changes:
- Add whisper-libs-legacy target with disabled AVX/AVX2/FMA instructions
- Add build-systray-legacy and appimage-legacy targets
- Add docker-appimage-legacy for containerized legacy builds
- Force clean rebuild for legacy to ensure compatibility
- Use GCC flags -mno-avx -mno-avx2 -mno-fma -mno-f16c for whisper.cpp

This addresses SIGILL crashes on older CPUs that don't support modern vector instruction sets while maintaining optimized builds for newer hardware.

Legacy AppImage filename: speak-to-ai-legacy-{version}.AppImage
