### PR TITLE
Add GPU acceleration (Vulkan/CPU)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,23 +5,29 @@ general:
   debug: false
   whisper_model: "small-q5_1"
   temp_audio_path: "/tmp"
-  language: "en"  # Recognition language: "en", "ru", "de", "fr", "es", "he", etc.
+  language: "en" # Recognition language: "en", "ru", "de", "fr", "es", "he", etc.
+
+# Runtime acceleration settings
+acceleration:
+  backend: "auto" # Options: "auto", "vulkan", "cpu"
+  gpu_device: -1 # Use -1 for automatic device selection
+  allow_fallback: true # Fallback to CPU if the selected backend fails
 
 # Hotkey settings
 hotkeys:
-  start_recording: "alt+r"            # Start/stop recording
-  stop_recording: "alt+r"             # Same combination for start/stop
+  start_recording: "alt+r" # Start/stop recording
+  stop_recording: "alt+r" # Same combination for start/stop
   # toggle_vad: "altgr+shift+v"          # Toggle VAD on/off
-  show_config: "alt+c"                # Open configuration file
-  reset_to_defaults: "alt+d"          # Reset all settings to defaults
+  show_config: "alt+c" # Open configuration file
+  reset_to_defaults: "alt+d" # Reset all settings to defaults
 
 # Audio recording settings
 audio:
   device: "default"
-  sample_rate: 16000            # Optimal for speech recognition (do not change)
-  format: "s16le"               # Note: audio is always recorded in mono (1 channel)
-  recording_method: "arecord"   # Options: "arecord", "ffmpeg"
-  temp_file_cleanup_time: 30    # Auto-delete temporary audio files older than X minutes (default: 30)
+  sample_rate: 16000 # Optimal for speech recognition (do not change)
+  format: "s16le" # Note: audio is always recorded in mono (1 channel)
+  recording_method: "arecord" # Options: "arecord", "ffmpeg"
+  temp_file_cleanup_time: 30 # Auto-delete temporary audio files older than X minutes (default: 30)
   # TODO: Next feature - VAD implementation
   # enable_vad: false           # Enable Voice Activity Detection
   # vad_sensitivity: "medium"   # VAD sensitivity: "low", "medium", "high"
@@ -29,12 +35,12 @@ audio:
 
 # Text output settings
 output:
-  default_mode: "active_window"  # Options: "clipboard", "active_window"
-  clipboard_tool: "auto"  # Options: "auto", "wl-copy", "xsel"
-  type_tool: "auto"  # Options: "auto", "ydotool", "xdotool", "wl-clipboard", "dbus"
+  default_mode: "active_window" # Options: "clipboard", "active_window"
+  clipboard_tool: "auto" # Options: "auto", "wl-copy", "xsel"
+  type_tool: "auto" # Options: "auto", "ydotool", "xdotool", "wl-clipboard", "dbus"
 
 # Web server settings
 web_server:
-  enabled: false  # Disabled by default - enable only if needed
+  enabled: false # Disabled by default - enable only if needed
   port: 8080
-  host: "localhost" 
+  host: "localhost"

--- a/config/loaders/yaml_loader.go
+++ b/config/loaders/yaml_loader.go
@@ -61,6 +61,11 @@ func SetDefaultConfig(config *models.Config) {
 	config.General.TempAudioPath = "/tmp"
 	config.General.Language = "en" // Default to English
 
+	// Acceleration settings
+	config.Acceleration.Backend = "auto"
+	config.Acceleration.GPUDevice = -1
+	config.Acceleration.AllowFallback = true
+
 	// Hotkey settings
 	config.Hotkeys.Provider = "auto"
 	config.Hotkeys.StartRecording = "alt+r"  // Start/stop recording

--- a/config/loaders/yaml_loader_test.go
+++ b/config/loaders/yaml_loader_test.go
@@ -145,6 +145,9 @@ func TestLoadConfig_NonExistentFile(t *testing.T) {
 	if config.General.WhisperModel != "small-q5_1" {
 		t.Errorf("expected default whisper model to be 'small-q5_1', got %s", config.General.WhisperModel)
 	}
+	if config.Acceleration.Backend != "auto" {
+		t.Errorf("expected default backend to be 'auto', got %s", config.Acceleration.Backend)
+	}
 }
 
 func TestLoadConfig_InvalidPermissions(t *testing.T) {
@@ -173,6 +176,9 @@ func TestLoadConfig_InvalidPermissions(t *testing.T) {
 	// Check that default values are set
 	if config.General.WhisperModel != "small-q5_1" {
 		t.Errorf("expected default whisper model to be 'small-q5_1', got %s", config.General.WhisperModel)
+	}
+	if config.Acceleration.Backend != "auto" {
+		t.Errorf("expected default backend to be 'auto', got %s", config.Acceleration.Backend)
 	}
 }
 

--- a/config/models/config.go
+++ b/config/models/config.go
@@ -20,6 +20,12 @@ type Config struct {
 		Language      string `yaml:"language"`        // Language for speech recognition (e.g., "en", "ru")
 	} `yaml:"general"`
 
+	Acceleration struct {
+		Backend       string `yaml:"backend"`        // Preferred backend: "auto", "vulkan", "cpu"
+		GPUDevice     int    `yaml:"gpu_device"`     // GPU device index (if applicable)
+		AllowFallback bool   `yaml:"allow_fallback"` // Whether to fallback to CPU when the backend fails
+	} `yaml:"acceleration"`
+
 	Hotkeys struct {
 		// Hotkey provider override. Use "auto" for automatic detection, or force a specific backend like "dbus" or "evdev"
 		Provider        string `yaml:"provider"`

--- a/config/validators/standard_validator.go
+++ b/config/validators/standard_validator.go
@@ -34,6 +34,22 @@ func ValidateConfig(config *models.Config) error {
 		}
 	}
 
+	accelBackend := strings.ToLower(config.Acceleration.Backend)
+	switch accelBackend {
+	case "", "auto":
+		config.Acceleration.Backend = "auto"
+	case "cpu", "vulkan":
+		config.Acceleration.Backend = accelBackend
+	default:
+		errors = append(errors, fmt.Sprintf("invalid acceleration backend: %s, defaulting to 'auto'", config.Acceleration.Backend))
+		config.Acceleration.Backend = "auto"
+	}
+
+	if config.Acceleration.GPUDevice < -1 {
+		errors = append(errors, fmt.Sprintf("invalid gpu_device: %d, correcting to -1", config.Acceleration.GPUDevice))
+		config.Acceleration.GPUDevice = -1
+	}
+
 	// Audio sample rate must be within a reasonable range for audio processing
 	if config.Audio.SampleRate < 8000 || config.Audio.SampleRate > 48000 {
 		errors = append(errors, fmt.Sprintf("invalid sample rate: %d, correcting to 16000", config.Audio.SampleRate))

--- a/whisper/runtime/consts.go
+++ b/whisper/runtime/consts.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
+package runtime
+
+import (
+	"errors"
+
+	// Low-level bindings
+	whispercpp "github.com/ggerganov/whisper.cpp/bindings/go"
+)
+
+///////////////////////////////////////////////////////////////////////////////
+// ERRORS
+
+var (
+	ErrUnableToLoadModel    = errors.New("unable to load model")
+	ErrInternalAppError     = errors.New("internal application error")
+	ErrProcessingFailed     = errors.New("processing failed")
+	ErrUnsupportedLanguage  = errors.New("unsupported language")
+	ErrModelNotMultilingual = errors.New("model is not multilingual")
+)
+
+///////////////////////////////////////////////////////////////////////////////
+// CONSTANTS
+
+// SampleRate is the sample rate of the audio data.
+const SampleRate = whispercpp.SampleRate
+
+// SampleBits is the number of bytes per sample.
+const SampleBits = whispercpp.SampleBits

--- a/whisper/runtime/context.go
+++ b/whisper/runtime/context.go
@@ -1,0 +1,351 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
+package runtime
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+	"strings"
+	"time"
+
+	// Low-level bindings
+	whispercpp "github.com/ggerganov/whisper.cpp/bindings/go"
+)
+
+///////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+type context struct {
+	n      int
+	model  *model
+	params whispercpp.Params
+}
+
+// Make sure context adheres to the interface
+var _ Context = (*context)(nil)
+
+///////////////////////////////////////////////////////////////////////////////
+// LIFECYCLE
+
+func newContext(model *model, params whispercpp.Params) (Context, error) {
+	context := new(context)
+	context.model = model
+	context.params = params
+
+	// Return success
+	return context, nil
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// PUBLIC METHODS
+
+// Set the language to use for speech recognition.
+func (context *context) SetLanguage(lang string) error {
+	if context.model.ctx == nil {
+		return ErrInternalAppError
+	}
+	if !context.model.IsMultilingual() {
+		return ErrModelNotMultilingual
+	}
+
+	if lang == "auto" {
+		context.params.SetLanguage(-1)
+	} else if id := context.model.ctx.Whisper_lang_id(lang); id < 0 {
+		return ErrUnsupportedLanguage
+	} else if err := context.params.SetLanguage(id); err != nil {
+		return err
+	}
+	// Return success
+	return nil
+}
+
+func (context *context) IsMultilingual() bool {
+	return context.model.IsMultilingual()
+}
+
+// Get language.
+func (context *context) Language() string {
+	id := context.params.Language()
+	if id == -1 {
+		return "auto"
+	}
+	return whispercpp.Whisper_lang_str(context.params.Language())
+}
+
+func (context *context) DetectedLanguage() string {
+	return whispercpp.Whisper_lang_str(context.model.ctx.Whisper_full_lang_id())
+}
+
+// Set translate flag.
+func (context *context) SetTranslate(v bool) {
+	context.params.SetTranslate(v)
+}
+
+func (context *context) SetSplitOnWord(v bool) {
+	context.params.SetSplitOnWord(v)
+}
+
+// Set number of threads to use.
+func (context *context) SetThreads(v uint) {
+	context.params.SetThreads(int(v))
+}
+
+// Set time offset.
+func (context *context) SetOffset(v time.Duration) {
+	context.params.SetOffset(int(v.Milliseconds()))
+}
+
+// Set duration of audio to process.
+func (context *context) SetDuration(v time.Duration) {
+	context.params.SetDuration(int(v.Milliseconds()))
+}
+
+// Set timestamp token probability threshold (~0.01).
+func (context *context) SetTokenThreshold(t float32) {
+	context.params.SetTokenThreshold(t)
+}
+
+// Set timestamp token sum probability threshold (~0.01).
+func (context *context) SetTokenSumThreshold(t float32) {
+	context.params.SetTokenSumThreshold(t)
+}
+
+// Set max segment length in characters.
+func (context *context) SetMaxSegmentLength(n uint) {
+	context.params.SetMaxSegmentLength(int(n))
+}
+
+// Set token timestamps flag.
+func (context *context) SetTokenTimestamps(b bool) {
+	context.params.SetTokenTimestamps(b)
+}
+
+// Set max tokens per segment (0 = no limit).
+func (context *context) SetMaxTokensPerSegment(n uint) {
+	context.params.SetMaxTokensPerSegment(int(n))
+}
+
+// Set audio encoder context.
+func (context *context) SetAudioCtx(n uint) {
+	context.params.SetAudioCtx(int(n))
+}
+
+// Set maximum number of text context tokens to store.
+func (context *context) SetMaxContext(n int) {
+	context.params.SetMaxContext(n)
+}
+
+// Set Beam Size.
+func (context *context) SetBeamSize(n int) {
+	context.params.SetBeamSize(n)
+}
+
+// Set Entropy threshold.
+func (context *context) SetEntropyThold(t float32) {
+	context.params.SetEntropyThold(t)
+}
+
+// Set Temperature.
+func (context *context) SetTemperature(t float32) {
+	context.params.SetTemperature(t)
+}
+
+// Set the fallback temperature incrementation.
+// Pass -1.0 to disable this feature.
+func (context *context) SetTemperatureFallback(t float32) {
+	context.params.SetTemperatureFallback(t)
+}
+
+// Set initial prompt.
+func (context *context) SetInitialPrompt(prompt string) {
+	context.params.SetInitialPrompt(prompt)
+}
+
+// ResetTimings resets the mode timings. Should be called before processing.
+func (context *context) ResetTimings() {
+	context.model.ctx.Whisper_reset_timings()
+}
+
+// PrintTimings prints the model timings to stdout.
+func (context *context) PrintTimings() {
+	context.model.ctx.Whisper_print_timings()
+}
+
+// SystemInfo returns the system information.
+func (context *context) SystemInfo() string {
+	return fmt.Sprintf("system_info: n_threads = %d / %d | %s\n",
+		context.params.Threads(),
+		runtime.NumCPU(),
+		whispercpp.Whisper_print_system_info(),
+	)
+}
+
+// Use mel data at offset_ms to try and auto-detect the spoken language.
+// Make sure to call whisper_pcm_to_mel() or whisper_set_mel() first.
+// Returns the probabilities of all languages.
+func (context *context) WhisperLangAutoDetect(offset_ms int, n_threads int) ([]float32, error) {
+	langProbs, err := context.model.ctx.Whisper_lang_auto_detect(offset_ms, n_threads)
+	if err != nil {
+		return nil, err
+	}
+	return langProbs, nil
+}
+
+// Process new sample data and return any errors.
+func (context *context) Process(
+	data []float32,
+	callEncoderBegin EncoderBeginCallback,
+	callNewSegment SegmentCallback,
+	callProgress ProgressCallback,
+) error {
+	if context.model.ctx == nil {
+		return ErrInternalAppError
+	}
+	// If the callback is defined then we force on single_segment mode.
+	if callNewSegment != nil {
+		context.params.SetSingleSegment(true)
+	}
+
+	// We don't do parallel processing at the moment.
+	processors := 0
+	if processors > 1 {
+		if err := context.model.ctx.Whisper_full_parallel(context.params, data, processors, callEncoderBegin,
+			func(new int) {
+				if callNewSegment != nil {
+					numSegments := context.model.ctx.Whisper_full_n_segments()
+					s0 := numSegments - new
+					for i := s0; i < numSegments; i++ {
+						callNewSegment(toSegment(context.model.ctx, i))
+					}
+				}
+			}); err != nil {
+			return err
+		}
+	} else if err := context.model.ctx.Whisper_full(context.params, data, callEncoderBegin,
+		func(new int) {
+			if callNewSegment != nil {
+				numSegments := context.model.ctx.Whisper_full_n_segments()
+				s0 := numSegments - new
+				for i := s0; i < numSegments; i++ {
+					callNewSegment(toSegment(context.model.ctx, i))
+				}
+			}
+		}, func(progress int) {
+			if callProgress != nil {
+				callProgress(progress)
+			}
+		}); err != nil {
+		return err
+	}
+
+	// Return success.
+	return nil
+}
+
+// Return the next segment of tokens.
+func (context *context) NextSegment() (Segment, error) {
+	if context.model.ctx == nil {
+		return Segment{}, ErrInternalAppError
+	}
+	if context.n >= context.model.ctx.Whisper_full_n_segments() {
+		return Segment{}, io.EOF
+	}
+
+	// Populate result.
+	result := toSegment(context.model.ctx, context.n)
+
+	// Increment the cursor.
+	context.n++
+
+	// Return success.
+	return result, nil
+}
+
+// Test for text tokens.
+func (context *context) IsText(t Token) bool {
+	switch {
+	case context.IsBEG(t):
+		return false
+	case context.IsSOT(t):
+		return false
+	case whispercpp.Token(t.Id) >= context.model.ctx.Whisper_token_eot():
+		return false
+	case context.IsPREV(t):
+		return false
+	case context.IsSOLM(t):
+		return false
+	case context.IsNOT(t):
+		return false
+	default:
+		return true
+	}
+}
+
+// Test for "begin" token.
+func (context *context) IsBEG(t Token) bool {
+	return whispercpp.Token(t.Id) == context.model.ctx.Whisper_token_beg()
+}
+
+// Test for "start of transcription" token.
+func (context *context) IsSOT(t Token) bool {
+	return whispercpp.Token(t.Id) == context.model.ctx.Whisper_token_sot()
+}
+
+// Test for "end of transcription" token.
+func (context *context) IsEOT(t Token) bool {
+	return whispercpp.Token(t.Id) == context.model.ctx.Whisper_token_eot()
+}
+
+// Test for "start of prev" token.
+func (context *context) IsPREV(t Token) bool {
+	return whispercpp.Token(t.Id) == context.model.ctx.Whisper_token_prev()
+}
+
+// Test for "start of lm" token.
+func (context *context) IsSOLM(t Token) bool {
+	return whispercpp.Token(t.Id) == context.model.ctx.Whisper_token_solm()
+}
+
+// Test for "No timestamps" token.
+func (context *context) IsNOT(t Token) bool {
+	return whispercpp.Token(t.Id) == context.model.ctx.Whisper_token_not()
+}
+
+// Test for token associated with a specific language.
+func (context *context) IsLANG(t Token, lang string) bool {
+	if id := context.model.ctx.Whisper_lang_id(lang); id >= 0 {
+		return whispercpp.Token(t.Id) == context.model.ctx.Whisper_token_lang(id)
+	}
+	return false
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// PRIVATE METHODS
+
+func toSegment(ctx *whispercpp.Context, n int) Segment {
+	return Segment{
+		Num:    n,
+		Text:   strings.TrimSpace(ctx.Whisper_full_get_segment_text(n)),
+		Start:  time.Duration(ctx.Whisper_full_get_segment_t0(n)) * time.Millisecond * 10,
+		End:    time.Duration(ctx.Whisper_full_get_segment_t1(n)) * time.Millisecond * 10,
+		Tokens: toTokens(ctx, n),
+	}
+}
+
+func toTokens(ctx *whispercpp.Context, n int) []Token {
+	result := make([]Token, ctx.Whisper_full_n_tokens(n))
+	for i := 0; i < len(result); i++ {
+		data := ctx.Whisper_full_get_token_data(n, i)
+
+		result[i] = Token{
+			Id:    int(ctx.Whisper_full_get_token_id(n, i)),
+			Text:  ctx.Whisper_full_get_token_text(n, i),
+			P:     ctx.Whisper_full_get_token_p(n, i),
+			Start: time.Duration(data.T0()) * time.Millisecond * 10,
+			End:   time.Duration(data.T1()) * time.Millisecond * 10,
+		}
+	}
+	return result
+}

--- a/whisper/runtime/interface.go
+++ b/whisper/runtime/interface.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
+package runtime
+
+import (
+	"io"
+	"time"
+)
+
+///////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+// SegmentCallback is the callback function for processing segments in real
+// time. It is called during the Process function.
+type SegmentCallback func(Segment)
+
+// ProgressCallback is the callback function for reporting progress during
+// processing. It is called during the Process function.
+type ProgressCallback func(int)
+
+// EncoderBeginCallback is the callback function for checking if we want to
+// continue processing. It is called during the Process function.
+type EncoderBeginCallback func() bool
+
+// Model is the interface to a whisper model. Create a new model with New().
+type Model interface {
+	io.Closer
+
+	// Return a new speech-to-text context.
+	NewContext() (Context, error)
+
+	// Backend describes the active execution backend.
+	Backend() BackendType
+
+	// Return true if the model is multilingual.
+	IsMultilingual() bool
+
+	// Return all languages supported.
+	Languages() []string
+}
+
+// Context is the speech recognition context.
+type Context interface {
+	SetLanguage(string) error // Set the language to use for speech recognition, use "auto" for auto detect language.
+	SetTranslate(bool)        // Set translate flag
+	IsMultilingual() bool     // Return true if the model is multilingual.
+	Language() string         // Get language
+	DetectedLanguage() string // Get detected language
+
+	SetOffset(time.Duration)          // Set offset
+	SetDuration(time.Duration)        // Set duration
+	SetThreads(uint)                  // Set number of threads to use
+	SetSplitOnWord(bool)              // Set split on word flag
+	SetTokenThreshold(float32)        // Set timestamp token probability threshold
+	SetTokenSumThreshold(float32)     // Set timestamp token sum probability threshold
+	SetMaxSegmentLength(uint)         // Set max segment length in characters
+	SetTokenTimestamps(bool)          // Set token timestamps flag
+	SetMaxTokensPerSegment(uint)      // Set max tokens per segment (0 = no limit)
+	SetAudioCtx(uint)                 // Set audio encoder context
+	SetMaxContext(n int)              // Set maximum number of text context tokens to store
+	SetBeamSize(n int)                // Set Beam Size
+	SetEntropyThold(t float32)        // Set Entropy threshold
+	SetInitialPrompt(prompt string)   // Set initial prompt
+	SetTemperature(t float32)         // Set temperature
+	SetTemperatureFallback(t float32) // Set temperature incrementation
+
+	// Process mono audio data and return any errors.
+	// If defined, newly generated segments are passed to the
+	// callback function during processing.
+	Process([]float32, EncoderBeginCallback, SegmentCallback, ProgressCallback) error
+
+	// After process is called, return segments until the end of the stream
+	// is reached, when io.EOF is returned.
+	NextSegment() (Segment, error)
+
+	IsBEG(Token) bool          // Test for "begin" token
+	IsSOT(Token) bool          // Test for "start of transcription" token
+	IsEOT(Token) bool          // Test for "end of transcription" token
+	IsPREV(Token) bool         // Test for "start of prev" token
+	IsSOLM(Token) bool         // Test for "start of lm" token
+	IsNOT(Token) bool          // Test for "No timestamps" token
+	IsLANG(Token, string) bool // Test for token associated with a specific language
+	IsText(Token) bool         // Test for text token
+
+	// Timings
+	PrintTimings()
+	ResetTimings()
+
+	SystemInfo() string
+}
+
+// Segment is the text result of a speech recognition.
+type Segment struct {
+	// Segment Number
+	Num int
+
+	// Time beginning and end timestamps for the segment.
+	Start, End time.Duration
+
+	// The text of the segment.
+	Text string
+
+	// The tokens of the segment.
+	Tokens []Token
+}
+
+// Token is a text or special token.
+type Token struct {
+	Id         int
+	Text       string
+	P          float32
+	Start, End time.Duration
+}

--- a/whisper/runtime/loader.go
+++ b/whisper/runtime/loader.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
+package runtime
+
+/*
+#cgo LDFLAGS: -lwhisper -lggml -lggml-base -lggml-cpu -lm -lstdc++ -fopenmp
+#include <whisper.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+#include <ggml-backend.h>
+
+typedef int (*ggml_vk_get_device_count_t)(void);
+
+static int whisper_vulkan_device_count() {
+	void *handle = dlopen("libggml-vulkan.so", RTLD_LAZY | RTLD_LOCAL);
+	if (handle == NULL) {
+		return -1;
+	}
+	ggml_vk_get_device_count_t fn = (ggml_vk_get_device_count_t)dlsym(handle, "ggml_backend_vk_get_device_count");
+	if (fn == NULL) {
+		dlclose(handle);
+		return -1;
+	}
+	int count = fn();
+	dlclose(handle);
+	return count;
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"unsafe"
+
+	whispercpp "github.com/ggerganov/whisper.cpp/bindings/go"
+)
+
+func loadContext(path string, backend BackendType, gpuDevice int) (*whispercpp.Context, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	ensureBackendsLoaded()
+
+	params := C.whisper_context_default_params()
+
+	switch backend {
+	case BackendCPU:
+		params.use_gpu = C.bool(false)
+	case BackendVulkan:
+		if C.whisper_vulkan_device_count() <= 0 {
+			return nil, fmt.Errorf("no Vulkan devices detected")
+		}
+		params.use_gpu = C.bool(true)
+		params.flash_attn = C.bool(false)
+		if gpuDevice >= 0 {
+			params.gpu_device = C.int(gpuDevice)
+		} else {
+			params.gpu_device = C.int(-1)
+		}
+	default:
+		params.use_gpu = C.bool(false)
+	}
+
+	ctx := C.whisper_init_from_file_with_params(cPath, params)
+	if ctx == nil {
+		return nil, fmt.Errorf("%w: %s backend", ErrUnableToLoadModel, backend)
+	}
+
+	return (*whispercpp.Context)(ctx), nil
+}
+
+var backendRegistryOnce sync.Once
+
+func ensureBackendsLoaded() {
+	backendRegistryOnce.Do(func() {
+		if dir := os.Getenv("GGML_BACKEND_PATH"); dir != "" {
+			for _, entry := range strings.Split(dir, ":") {
+				entry = strings.TrimSpace(entry)
+				if entry == "" {
+					continue
+				}
+				cDir := C.CString(entry)
+				C.ggml_backend_load_all_from_path(cDir)
+				C.free(unsafe.Pointer(cDir))
+			}
+		}
+		C.ggml_backend_load_all()
+	})
+}

--- a/whisper/runtime/model.go
+++ b/whisper/runtime/model.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	// Low-level bindings
+	whispercpp "github.com/ggerganov/whisper.cpp/bindings/go"
+)
+
+///////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+type model struct {
+	path    string
+	ctx     *whispercpp.Context
+	backend BackendType
+}
+
+// Make sure model adheres to the interface
+var _ Model = (*model)(nil)
+
+///////////////////////////////////////////////////////////////////////////////
+// LIFECYCLE
+
+// New mirrors the upstream API but uses the default GPU-aware options.
+func New(path string) (Model, error) {
+	return NewWithOptions(path, DefaultOptions())
+}
+
+// NewWithOptions initialises a Whisper model with explicit runtime options.
+func NewWithOptions(path string, opts Options) (Model, error) {
+	if _, err := os.Stat(path); err != nil {
+		return nil, err
+	}
+
+	ctx, backend, err := initialiseContext(path, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	model := &model{
+		ctx:     ctx,
+		path:    path,
+		backend: backend,
+	}
+
+	// Return success.
+	return model, nil
+}
+
+func (model *model) Close() error {
+	if model.ctx != nil {
+		model.ctx.Whisper_free()
+	}
+
+	// Release resources
+	model.ctx = nil
+
+	// Return success
+	return nil
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// STRINGIFY
+
+func (model *model) String() string {
+	str := "<whisper.model"
+	if model.ctx != nil {
+		str += fmt.Sprintf(" model=%q backend=%s", model.path, model.backend)
+	}
+	return str + ">"
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// PUBLIC METHODS
+
+// Return true if model is multilingual (language and translation options are supported).
+func (model *model) IsMultilingual() bool {
+	return model.ctx.Whisper_is_multilingual() != 0
+}
+
+// Return all recognized languages. Initially it is set to auto-detect.
+func (model *model) Languages() []string {
+	result := make([]string, 0, whispercpp.Whisper_lang_max_id())
+	for i := 0; i < whispercpp.Whisper_lang_max_id(); i++ {
+		str := whispercpp.Whisper_lang_str(i)
+		if model.ctx.Whisper_lang_id(str) >= 0 {
+			result = append(result, str)
+		}
+	}
+	return result
+}
+
+func (model *model) NewContext() (Context, error) {
+	if model.ctx == nil {
+		return nil, ErrInternalAppError
+	}
+
+	// Create new context
+	params := model.ctx.Whisper_full_default_params(whispercpp.SAMPLING_GREEDY)
+	params.SetTranslate(false)
+	params.SetPrintSpecial(false)
+	params.SetPrintProgress(false)
+	params.SetPrintRealtime(false)
+	params.SetPrintTimestamps(false)
+	params.SetThreads(runtime.NumCPU())
+	params.SetNoContext(true)
+
+	// Return new context
+	return newContext(model, params)
+}
+
+func (model *model) Backend() BackendType {
+	return model.backend
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// HELPERS
+
+func initialiseContext(path string, opts Options) (*whispercpp.Context, BackendType, error) {
+	var lastErr error
+	for _, backend := range orderedBackends(opts) {
+		ctx, err := loadContext(path, backend, opts.GPUDevice)
+		if err == nil {
+			return ctx, backend, nil
+		}
+		lastErr = err
+	}
+
+	if lastErr == nil {
+		lastErr = ErrUnableToLoadModel
+	}
+	return nil, BackendCPU, lastErr
+}
+
+func orderedBackends(opts Options) []BackendType {
+	switch opts.Backend {
+	case BackendCPU:
+		return []BackendType{BackendCPU}
+	case BackendVulkan:
+		if opts.AllowFallback {
+			return []BackendType{BackendVulkan, BackendCPU}
+		}
+		return []BackendType{BackendVulkan}
+	default: // BackendAuto and unknowns
+		if opts.AllowFallback {
+			return []BackendType{BackendVulkan, BackendCPU}
+		}
+		return []BackendType{BackendVulkan}
+	}
+}

--- a/whisper/runtime/options.go
+++ b/whisper/runtime/options.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
+package runtime
+
+// BackendType identifies the preferred execution backend for the Whisper model.
+type BackendType string
+
+const (
+	// BackendAuto prefers GPU execution when available and falls back to CPU.
+	BackendAuto BackendType = "auto"
+	// BackendCPU forces CPU execution.
+	BackendCPU BackendType = "cpu"
+	// BackendVulkan requests the Vulkan backend explicitly.
+	BackendVulkan BackendType = "vulkan"
+)
+
+// Options configure how a Whisper model should be initialised.
+type Options struct {
+	// Backend selects the preferred backend. Defaults to BackendAuto.
+	Backend BackendType
+	// GPUDevice allows selecting a GPU device (for CUDA style backends). Use -1 for auto.
+	GPUDevice int
+	// AllowFallback toggles automatic fallback to CPU when the preferred backend is unavailable.
+	AllowFallback bool
+}
+
+// DefaultOptions returns the recommended default options.
+func DefaultOptions() Options {
+	return Options{
+		Backend:       BackendAuto,
+		GPUDevice:     -1,
+		AllowFallback: true,
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds optional Vulkan acceleration and automatic CPU fallback; build picks up the Vulkan backend when the toolchain is present, and the AppImage gathers the Vulkan runtime libraries so it can run on GPU-capable hosts, otherwise it runs on CPU.

## Checklist

- [X] My code follows the project's coding standards
- [X] I have added license headers to new Go files
- [ ] I have updated documentation as needed
- [x] All new and existing tests pass - run `make test`
- [ ] Formatter and Linter pass - run `make fmt && make lint`
- [ ] CI green