### PR TITLE
refactor/reduce cyclomatic complexity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install golangci-lint
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-            sh -s -- -b $(go env GOPATH)/bin v2.4.0
+            sh -s -- -b $(go env GOPATH)/bin v2.6.1
 
       - name: Diagnostics before golangci-lint
         env:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,3 +22,8 @@ linters:
     - unconvert
     - unused
     - unparam
+    - gocyclo
+
+linters-settings:
+  gocyclo:
+    min-complexity: 15

--- a/config/validators/standard_validator.go
+++ b/config/validators/standard_validator.go
@@ -12,16 +12,11 @@ import (
 	"github.com/AshBuk/speak-to-ai/config/models"
 )
 
-// Inspect the configuration for invalid or unsafe values.
-// It automatically corrects offending values to safe defaults and returns an error
-// that aggregates all validation issues found. This ensures the application can
-// always run with a sane configuration
-func ValidateConfig(config *models.Config) error {
-	var errors []string
-
+// validateGeneralConfig validates general configuration settings
+func validateGeneralConfig(config *models.Config, errors *[]string) {
 	// The whisper model is fixed to a specific version for consistency
 	if config.General.WhisperModel != "small-q5_1" {
-		errors = append(errors, fmt.Sprintf("invalid whisper model: %s, using 'small-q5_1'", config.General.WhisperModel))
+		*errors = append(*errors, fmt.Sprintf("invalid whisper model: %s, using 'small-q5_1'", config.General.WhisperModel))
 		config.General.WhisperModel = "small-q5_1"
 	}
 
@@ -30,13 +25,16 @@ func ValidateConfig(config *models.Config) error {
 		config.General.TempAudioPath = filepath.Clean(config.General.TempAudioPath)
 		if strings.Contains(config.General.TempAudioPath, "..") {
 			config.General.TempAudioPath = "/tmp"
-			errors = append(errors, "suspicious temp audio path sanitized to /tmp")
+			*errors = append(*errors, "suspicious temp audio path sanitized to /tmp")
 		}
 	}
+}
 
+// validateAudioConfig validates audio configuration settings
+func validateAudioConfig(config *models.Config, errors *[]string) {
 	// Audio sample rate must be within a reasonable range for audio processing
 	if config.Audio.SampleRate < 8000 || config.Audio.SampleRate > 48000 {
-		errors = append(errors, fmt.Sprintf("invalid sample rate: %d, correcting to 16000", config.Audio.SampleRate))
+		*errors = append(*errors, fmt.Sprintf("invalid sample rate: %d, correcting to 16000", config.Audio.SampleRate))
 		config.Audio.SampleRate = 16000
 	}
 
@@ -46,41 +44,62 @@ func ValidateConfig(config *models.Config) error {
 		"ffmpeg":  true,
 	}
 	if !validRecordingMethods[config.Audio.RecordingMethod] {
-		errors = append(errors, fmt.Sprintf("invalid recording method: %s, correcting to 'arecord'", config.Audio.RecordingMethod))
+		*errors = append(*errors, fmt.Sprintf("invalid recording method: %s, correcting to 'arecord'", config.Audio.RecordingMethod))
 		config.Audio.RecordingMethod = "arecord"
 	}
 
 	// Max recording time is capped to prevent accidental resource exhaustion
 	if config.Audio.MaxRecordingTime <= 0 || config.Audio.MaxRecordingTime > 1800 { // 30 minutes
-		errors = append(errors, fmt.Sprintf("invalid max recording time: %d, correcting to 300s", config.Audio.MaxRecordingTime))
+		*errors = append(*errors, fmt.Sprintf("invalid max recording time: %d, correcting to 300s", config.Audio.MaxRecordingTime))
 		config.Audio.MaxRecordingTime = 300 // 5 minutes
 	}
+}
 
-	// Validate web server settings if it's enabled
-	if config.WebServer.Enabled {
-		if config.WebServer.Port <= 0 || config.WebServer.Port > 65535 {
-			errors = append(errors, fmt.Sprintf("invalid port: %d, correcting to 8080", config.WebServer.Port))
-			config.WebServer.Port = 8080
-		}
-
-		// Host must be a valid hostname
-		if config.WebServer.Host == "" {
-			config.WebServer.Host = "localhost"
-		} else {
-			// Basic validation to prevent injection of malicious characters
-			hostRegex := regexp.MustCompile(`^[a-zA-Z0-9.-]+$`)
-			if !hostRegex.MatchString(config.WebServer.Host) {
-				errors = append(errors, fmt.Sprintf("invalid host: %s, correcting to 'localhost'", config.WebServer.Host))
-				config.WebServer.Host = "localhost"
-			}
-		}
+// validateWebServerConfig validates web server configuration settings
+func validateWebServerConfig(config *models.Config, errors *[]string) {
+	if !config.WebServer.Enabled {
+		return
 	}
 
+	if config.WebServer.Port <= 0 || config.WebServer.Port > 65535 {
+		*errors = append(*errors, fmt.Sprintf("invalid port: %d, correcting to 8080", config.WebServer.Port))
+		config.WebServer.Port = 8080
+	}
+
+	// Host must be a valid hostname
+	if config.WebServer.Host == "" {
+		config.WebServer.Host = "localhost"
+		return
+	}
+
+	// Basic validation to prevent injection of malicious characters
+	hostRegex := regexp.MustCompile(`^[a-zA-Z0-9.-]+$`)
+	if !hostRegex.MatchString(config.WebServer.Host) {
+		*errors = append(*errors, fmt.Sprintf("invalid host: %s, correcting to 'localhost'", config.WebServer.Host))
+		config.WebServer.Host = "localhost"
+	}
+}
+
+// validateSecurityConfig validates security configuration settings
+func validateSecurityConfig(config *models.Config, errors *[]string) {
 	// Ensure there's always a baseline of allowed commands for security
 	if len(config.Security.AllowedCommands) == 0 {
 		config.Security.AllowedCommands = []string{"arecord", "ffmpeg", "whisper", "xdotool", "wl-copy", "xsel"}
-		errors = append(errors, "allowed_commands was empty, populated with defaults")
+		*errors = append(*errors, "allowed_commands was empty, populated with defaults")
 	}
+}
+
+// Inspect the configuration for invalid or unsafe values.
+// It automatically corrects offending values to safe defaults and returns an error
+// that aggregates all validation issues found. This ensures the application can
+// always run with a sane configuration
+func ValidateConfig(config *models.Config) error {
+	var errors []string
+
+	validateGeneralConfig(config, &errors)
+	validateAudioConfig(config, &errors)
+	validateWebServerConfig(config, &errors)
+	validateSecurityConfig(config, &errors)
 
 	if len(errors) > 0 {
 		return fmt.Errorf("configuration validation issues: %s", strings.Join(errors, "; "))

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y --no-install
 
 # Install golangci-lint
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-    | sh -s -- -b /usr/local/bin v2.4.0
+    | sh -s -- -b /usr/local/bin v2.6.1
 
 # Set working directory
 WORKDIR /app

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -11,132 +11,128 @@ import (
 	"github.com/AshBuk/speak-to-ai/internal/testutils"
 )
 
-func TestRuntimeContext(t *testing.T) {
+func TestRuntimeContext_NewRuntimeContext(t *testing.T) {
 	mockLogger := testutils.NewMockLogger()
+	runtime := NewRuntimeContext(mockLogger)
 
-	t.Run("NewRuntimeContext", func(t *testing.T) {
-		runtime := NewRuntimeContext(mockLogger)
+	if runtime == nil {
+		t.Fatal("NewRuntimeContext returned nil")
+	}
+	if runtime.Logger != mockLogger {
+		t.Error("Logger not set correctly")
+	}
+	if runtime.Ctx == nil {
+		t.Error("Context not initialized")
+	}
+	if runtime.Cancel == nil {
+		t.Error("Cancel function not initialized")
+	}
+	if runtime.ShutdownCh == nil {
+		t.Error("Shutdown channel not initialized")
+	}
 
-		if runtime == nil {
-			t.Fatal("NewRuntimeContext returned nil")
-		}
-		if runtime.Logger != mockLogger {
-			t.Error("Logger not set correctly")
-		}
-		if runtime.Ctx == nil {
-			t.Error("Context not initialized")
-		}
-		if runtime.Cancel == nil {
-			t.Error("Cancel function not initialized")
-		}
-		if runtime.ShutdownCh == nil {
-			t.Error("Shutdown channel not initialized")
-		}
+	// Test that context is not cancelled initially
+	select {
+	case <-runtime.Ctx.Done():
+		t.Error("Context should not be cancelled initially")
+	default:
+		// Expected behavior
+	}
 
-		// Test that context is not cancelled initially
-		select {
-		case <-runtime.Ctx.Done():
-			t.Error("Context should not be cancelled initially")
-		default:
-			// Expected behavior
-		}
-
-		// Test cancellation
-		runtime.Cancel()
-		select {
-		case <-runtime.Ctx.Done():
-			// Expected behavior
-		case <-time.After(100 * time.Millisecond):
-			t.Error("Context should be cancelled after calling Cancel()")
-		}
-	})
-
-	t.Run("ShutdownChannel", func(t *testing.T) {
-		runtime := NewRuntimeContext(mockLogger)
-
-		// Test that shutdown channel is buffered
-		if cap(runtime.ShutdownCh) == 0 {
-			t.Error("Shutdown channel should be buffered")
-		}
-	})
+	// Test cancellation
+	runtime.Cancel()
+	select {
+	case <-runtime.Ctx.Done():
+		// Expected behavior
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Context should be cancelled after calling Cancel()")
+	}
 }
 
-func TestApp(t *testing.T) {
+func TestRuntimeContext_ShutdownChannel(t *testing.T) {
 	mockLogger := testutils.NewMockLogger()
+	runtime := NewRuntimeContext(mockLogger)
 
-	t.Run("NewApp", func(t *testing.T) {
-		app := NewApp(mockLogger)
+	// Test that shutdown channel is buffered
+	if cap(runtime.ShutdownCh) == 0 {
+		t.Error("Shutdown channel should be buffered")
+	}
+}
 
-		if app == nil {
-			t.Fatal("NewApp returned nil")
-		}
-		if app.Services == nil {
-			t.Error("Services container not initialized")
-		}
-		if app.Runtime == nil {
-			t.Error("Runtime context not initialized")
-		}
-		if app.Runtime.Logger != mockLogger {
-			t.Error("Runtime logger not set correctly")
-		}
-	})
+func TestApp_NewApp(t *testing.T) {
+	mockLogger := testutils.NewMockLogger()
+	app := NewApp(mockLogger)
 
-	t.Run("ServiceAccessors", func(t *testing.T) {
-		app := NewApp(mockLogger)
+	if app == nil {
+		t.Fatal("NewApp returned nil")
+	}
+	if app.Services == nil {
+		t.Error("Services container not initialized")
+	}
+	if app.Runtime == nil {
+		t.Error("Runtime context not initialized")
+	}
+	if app.Runtime.Logger != mockLogger {
+		t.Error("Runtime logger not set correctly")
+	}
+}
 
-		// Test accessor methods with nil services
-		if app.Audio() != nil {
-			t.Error("Audio() should return nil when service is not set")
-		}
-		if app.UI() != nil {
-			t.Error("UI() should return nil when service is not set")
-		}
-		if app.IO() != nil {
-			t.Error("IO() should return nil when service is not set")
-		}
-		if app.Config() != nil {
-			t.Error("Config() should return nil when service is not set")
-		}
-		if app.Hotkeys() != nil {
-			t.Error("Hotkeys() should return nil when service is not set")
-		}
+func TestApp_ServiceAccessors(t *testing.T) {
+	mockLogger := testutils.NewMockLogger()
+	app := NewApp(mockLogger)
 
-		// Test accessor methods with nil Services container
-		app.Services = nil
-		if app.Audio() != nil {
-			t.Error("Audio() should return nil when Services container is nil")
-		}
-		if app.UI() != nil {
-			t.Error("UI() should return nil when Services container is nil")
-		}
-		if app.IO() != nil {
-			t.Error("IO() should return nil when Services container is nil")
-		}
-		if app.Config() != nil {
-			t.Error("Config() should return nil when Services container is nil")
-		}
-		if app.Hotkeys() != nil {
-			t.Error("Hotkeys() should return nil when Services container is nil")
-		}
-	})
+	// Test accessor methods with nil services
+	if app.Audio() != nil {
+		t.Error("Audio() should return nil when service is not set")
+	}
+	if app.UI() != nil {
+		t.Error("UI() should return nil when service is not set")
+	}
+	if app.IO() != nil {
+		t.Error("IO() should return nil when service is not set")
+	}
+	if app.Config() != nil {
+		t.Error("Config() should return nil when service is not set")
+	}
+	if app.Hotkeys() != nil {
+		t.Error("Hotkeys() should return nil when service is not set")
+	}
 
-	t.Run("Shutdown_NilServices", func(t *testing.T) {
-		app := NewApp(mockLogger)
-		app.Services = nil
+	// Test accessor methods with nil Services container
+	app.Services = nil
+	if app.Audio() != nil {
+		t.Error("Audio() should return nil when Services container is nil")
+	}
+	if app.UI() != nil {
+		t.Error("UI() should return nil when Services container is nil")
+	}
+	if app.IO() != nil {
+		t.Error("IO() should return nil when Services container is nil")
+	}
+	if app.Config() != nil {
+		t.Error("Config() should return nil when Services container is nil")
+	}
+	if app.Hotkeys() != nil {
+		t.Error("Hotkeys() should return nil when Services container is nil")
+	}
+}
 
-		err := app.Shutdown()
-		if err != nil {
-			t.Errorf("Shutdown should not error with nil services: %v", err)
-		}
+func TestApp_Shutdown_NilServices(t *testing.T) {
+	mockLogger := testutils.NewMockLogger()
+	app := NewApp(mockLogger)
+	app.Services = nil
 
-		// Verify context was cancelled
-		select {
-		case <-app.Runtime.Ctx.Done():
-			// Expected behavior
-		case <-time.After(100 * time.Millisecond):
-			t.Error("Context should be cancelled after Shutdown()")
-		}
-	})
+	if err := app.Shutdown(); err != nil {
+		t.Errorf("Shutdown should not error with nil services: %v", err)
+	}
+
+	// Verify context was cancelled
+	select {
+	case <-app.Runtime.Ctx.Done():
+		// Expected behavior
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Context should be cancelled after Shutdown()")
+	}
 }
 
 // Mock services for testing
@@ -150,118 +146,102 @@ func (m *mockServiceWithShutdown) Shutdown() error {
 	return m.shutdownError
 }
 
-func TestApp_Integration(t *testing.T) {
+func TestApp_Integration_Shutdown_WithServices(t *testing.T) {
 	mockLogger := testutils.NewMockLogger()
+	app := NewApp(mockLogger)
 
-	t.Run("Shutdown_WithServices", func(t *testing.T) {
-		app := NewApp(mockLogger)
+	// Create a mock service container with our mock service
+	mockServices := &services.ServiceContainer{}
 
-		// Create a mock service container with our mock service
-		mockServices := &services.ServiceContainer{}
+	// We'll test that the service container's Shutdown is called
+	// Since we can't easily mock the entire service container,
+	// we'll test that the method handles the nil services gracefully
+	app.Services = mockServices
 
-		// We'll test that the service container's Shutdown is called
-		// Since we can't easily mock the entire service container,
-		// we'll test that the method handles the nil services gracefully
-		app.Services = mockServices
+	if err := app.Shutdown(); err != nil {
+		t.Errorf("Shutdown failed: %v", err)
+	}
 
-		err := app.Shutdown()
-		if err != nil {
-			t.Errorf("Shutdown failed: %v", err)
-		}
-
-		// Verify context was cancelled
-		select {
-		case <-app.Runtime.Ctx.Done():
-			// Expected behavior
-		case <-time.After(100 * time.Millisecond):
-			t.Error("Context should be cancelled after Shutdown()")
-		}
-	})
-
-	t.Run("AppLifecycle", func(t *testing.T) {
-		app := NewApp(mockLogger)
-
-		// Test initial state
-		if app.Runtime.Ctx.Err() != nil {
-			t.Error("Context should not be cancelled initially")
-		}
-
-		// Test shutdown
-		err := app.Shutdown()
-		if err != nil {
-			t.Errorf("Shutdown failed: %v", err)
-		}
-
-		// Verify context was cancelled
-		if app.Runtime.Ctx.Err() == nil {
-			t.Error("Context should be cancelled after shutdown")
-		}
-	})
+	// Verify context was cancelled
+	select {
+	case <-app.Runtime.Ctx.Done():
+		// Expected behavior
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Context should be cancelled after Shutdown()")
+	}
 }
 
-func TestApp_HandlerMethods(t *testing.T) {
+func TestApp_Integration_AppLifecycle(t *testing.T) {
 	mockLogger := testutils.NewMockLogger()
+	app := NewApp(mockLogger)
 
-	t.Run("Handlers_NilServices", func(t *testing.T) {
-		app := NewApp(mockLogger)
-		app.Services = nil
+	// Test initial state
+	if app.Runtime.Ctx.Err() != nil {
+		t.Error("Context should not be cancelled initially")
+	}
 
-		// Test all handler methods with nil services
-		err := app.handleStartRecording()
-		if err == nil {
-			t.Error("handleStartRecording should fail with nil services")
-		}
+	// Test shutdown
+	if err := app.Shutdown(); err != nil {
+		t.Errorf("Shutdown failed: %v", err)
+	}
 
-		err = app.handleStopRecordingAndTranscribe()
-		if err == nil {
-			t.Error("handleStopRecordingAndTranscribe should fail with nil services")
-		}
+	// Verify context was cancelled
+	if app.Runtime.Ctx.Err() == nil {
+		t.Error("Context should be cancelled after shutdown")
+	}
+}
 
-		// TODO: Next feature - VAD implementation
-		// err = app.handleToggleVAD()
-		// if err == nil {
-		//	t.Error("handleToggleVAD should fail with nil services")
-		// }
+func TestApp_HandlerMethods_NilServices(t *testing.T) {
+	mockLogger := testutils.NewMockLogger()
+	app := NewApp(mockLogger)
+	app.Services = nil
 
-		err = app.handleShowConfig()
-		if err == nil {
-			t.Error("handleShowConfig should fail with nil services")
-		}
+	// Test all handler methods with nil services
+	if err := app.handleStartRecording(); err == nil {
+		t.Error("handleStartRecording should fail with nil services")
+	}
 
-		err = app.handleResetToDefaults()
-		if err == nil {
-			t.Error("handleResetToDefaults should fail with nil services")
-		}
-	})
+	if err := app.handleStopRecordingAndTranscribe(); err == nil {
+		t.Error("handleStopRecordingAndTranscribe should fail with nil services")
+	}
 
-	t.Run("Handlers_NilSpecificServices", func(t *testing.T) {
-		app := NewApp(mockLogger)
-		// Services container exists but individual services are nil
+	// TODO: Next feature - VAD implementation
+	// if err := app.handleToggleVAD(); err == nil {
+	//	t.Error("handleToggleVAD should fail with nil services")
+	// }
 
-		err := app.handleStartRecording()
-		if err == nil {
-			t.Error("handleStartRecording should fail with nil audio service")
-		}
+	if err := app.handleShowConfig(); err == nil {
+		t.Error("handleShowConfig should fail with nil services")
+	}
 
-		err = app.handleStopRecordingAndTranscribe()
-		if err == nil {
-			t.Error("handleStopRecordingAndTranscribe should fail with nil audio service")
-		}
+	if err := app.handleResetToDefaults(); err == nil {
+		t.Error("handleResetToDefaults should fail with nil services")
+	}
+}
 
-		// TODO: Next feature - VAD implementation
-		// err = app.handleToggleVAD()
-		// if err == nil {
-		//	t.Error("handleToggleVAD should fail with nil config service")
-		// }
+func TestApp_HandlerMethods_NilSpecificServices(t *testing.T) {
+	mockLogger := testutils.NewMockLogger()
+	app := NewApp(mockLogger)
+	// Services container exists but individual services are nil
 
-		err = app.handleShowConfig()
-		if err == nil {
-			t.Error("handleShowConfig should fail with nil UI service")
-		}
+	if err := app.handleStartRecording(); err == nil {
+		t.Error("handleStartRecording should fail with nil audio service")
+	}
 
-		err = app.handleResetToDefaults()
-		if err == nil {
-			t.Error("handleResetToDefaults should fail with nil config service")
-		}
-	})
+	if err := app.handleStopRecordingAndTranscribe(); err == nil {
+		t.Error("handleStopRecordingAndTranscribe should fail with nil audio service")
+	}
+
+	// TODO: Next feature - VAD implementation
+	// if err := app.handleToggleVAD(); err == nil {
+	//	t.Error("handleToggleVAD should fail with nil config service")
+	// }
+
+	if err := app.handleShowConfig(); err == nil {
+		t.Error("handleShowConfig should fail with nil UI service")
+	}
+
+	if err := app.handleResetToDefaults(); err == nil {
+		t.Error("handleResetToDefaults should fail with nil config service")
+	}
 }

--- a/internal/services/callback_wirer.go
+++ b/internal/services/callback_wirer.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/AshBuk/speak-to-ai/config"
 	"github.com/AshBuk/speak-to-ai/hotkeys/adapters"
 	"github.com/AshBuk/speak-to-ai/internal/logger"
 )
@@ -29,154 +30,144 @@ func (cw *CallbackWirer) Wire(container *ServiceContainer, components *Component
 
 	// Core actions (toggle, show config, reset defaults)
 	components.TrayManager.SetCoreActions(
-		func() error { // toggle
-			if container == nil || container.Audio == nil {
-				return fmt.Errorf("audio service not available")
-			}
-			if container.Audio.IsRecording() {
-				return container.Audio.HandleStopRecording()
-			}
-			return container.Audio.HandleStartRecording()
-		},
-		func() error { // show config
-			if container == nil || container.UI == nil {
-				return fmt.Errorf("UI service not available")
-			}
-			return container.UI.ShowConfigFile()
-		},
-		func() error { // show about
-			if container == nil || container.UI == nil {
-				return fmt.Errorf("UI service not available")
-			}
-			return container.UI.ShowAboutPage()
-		},
-		func() error { // reset to defaults
-			if container == nil || container.Config == nil {
-				return fmt.Errorf("config service not available")
-			}
-
-			if err := container.Config.ResetToDefaults(); err != nil {
-				return err
-			}
-
-			// Hotkeys: reload manager to apply default combos immediately
-			if container.Hotkeys != nil {
-				cfgProvider := func() adapters.HotkeyConfig {
-					if cfgSvc, ok := container.Config.(*ConfigService); ok && cfgSvc != nil {
-						if cfg := cfgSvc.GetConfig(); cfg != nil {
-							return adapters.NewConfigAdapter(cfg.Hotkeys.StartRecording, cfg.Hotkeys.Provider).
-								WithAdditionalHotkeys(
-									"",
-									cfg.Hotkeys.ShowConfig,
-									cfg.Hotkeys.ResetToDefaults,
-								)
-						}
-					}
-					return adapters.NewConfigAdapter("", "auto")
-				}
-
-				// Ensure callbacks preserved
-				if err := container.Hotkeys.ReloadFromConfig(
-					func() error { return container.Audio.HandleStartRecording() },
-					func() error { return container.Audio.HandleStopRecording() },
-					cfgProvider,
-				); err != nil {
-					return err
-				}
-			}
-
-			return nil
-		},
+		cw.makeToggleCallback(container),
+		cw.makeShowConfigCallback(container),
+		cw.makeShowAboutCallback(container),
+		cw.makeResetToDefaultsCallback(container),
 	)
 
 	// Audio actions (recorder selection)
-	components.TrayManager.SetAudioActions(
-		func(method string) error {
-			// Persist method and reinit on next start
-			if container == nil || container.Config == nil {
-				return fmt.Errorf("config service not available")
-			}
-			if err := container.Config.UpdateRecordingMethod(method); err != nil {
-				return err
-			}
-			if audioSvc, ok := container.Audio.(*AudioService); ok {
-				audioSvc.clearSession()
-			}
-			// Update tray to reflect new selection immediately
-			if uiSvc, ok := container.UI.(*UIService); ok && uiSvc != nil {
-				if cfgSvc, ok2 := container.Config.(*ConfigService); ok2 && cfgSvc != nil {
-					if cfg := cfgSvc.GetConfig(); cfg != nil {
-						uiSvc.UpdateSettings(cfg)
-					}
-				}
-			}
-			return nil
-		},
-	)
+	components.TrayManager.SetAudioActions(cw.makeRecorderSelectionCallback(container))
 
 	// Settings actions (language, notifications)
-	// TODO: Next feature - VAD implementation
 	components.TrayManager.SetSettingsActions(
-		// TODO: Next feature - VAD implementation
-		// func(sensitivity string) error {
-		//	if container == nil || container.Config == nil {
-		//		return fmt.Errorf("config service not available")
-		//	}
-		//	return container.Config.UpdateVADSensitivity(sensitivity)
-		// },
-		func(language string) error {
-			if container == nil || container.Config == nil {
-				return fmt.Errorf("config service not available")
-			}
-
-			return container.Config.UpdateLanguage(language)
-		},
-		func() error {
-			if container == nil || container.Config == nil {
-				return fmt.Errorf("config service not available")
-			}
-			if err := container.Config.ToggleWorkflowNotifications(); err != nil {
-				return err
-			}
-			// Inform user about new state
-			if container.UI != nil {
-				enabled := "disabled"
-				if cfgSvc, ok := container.Config.(*ConfigService); ok && cfgSvc != nil {
-					if c := cfgSvc.GetConfig(); c != nil {
-						if c.Notifications.EnableWorkflowNotifications {
-							enabled = "enabled"
-						}
-					}
-				}
-				container.UI.ShowNotification("Workflow Notifications", "Now "+enabled)
-			}
-			return nil
-		},
-		func(mode string) error {
-			if container == nil || container.Config == nil || container.IO == nil {
-				return fmt.Errorf("services not available")
-			}
-			if err := container.Config.UpdateOutputMode(mode); err != nil {
-				return err
-			}
-			// Apply the output method change to IOService
-			if err := container.IO.SetOutputMethod(mode); err != nil {
-				return err
-			}
-			// Update tray to reflect new selection immediately
-			if uiSvc, ok := container.UI.(*UIService); ok && uiSvc != nil {
-				if cfgSvc, ok2 := container.Config.(*ConfigService); ok2 && cfgSvc != nil {
-					if cfg := cfgSvc.GetConfig(); cfg != nil {
-						uiSvc.UpdateSettings(cfg)
-					}
-				}
-			}
-			return nil
-		},
+		cw.makeLanguageCallback(container),
+		cw.makeToggleNotificationsCallback(container),
+		cw.makeOutputModeCallback(container),
 	)
 
 	// Set callback for getting actual output tool names
-	components.TrayManager.SetGetOutputToolsCallback(func() (clipboardTool, typeTool string) {
+	components.TrayManager.SetGetOutputToolsCallback(cw.makeGetOutputToolsCallback(container))
+
+	// Capture once support capability
+	components.TrayManager.SetCaptureOnceSupport(cw.makeCaptureOnceSupportCallback(container))
+
+	// Force UI update after callback is set
+	cw.updateTraySettings(container, components.TrayManager)
+
+	// Hotkeys rebind wiring
+	components.TrayManager.SetHotkeyRebindAction(cw.makeHotkeyRebindCallback(container))
+
+	// Ensure Quit exits app cleanly
+	components.TrayManager.SetExitAction(func() {
+		_ = syscall.Kill(os.Getpid(), syscall.SIGTERM)
+	})
+}
+
+func (cw *CallbackWirer) makeToggleCallback(container *ServiceContainer) func() error {
+	return func() error {
+		if container == nil || container.Audio == nil {
+			return fmt.Errorf("audio service not available")
+		}
+		if container.Audio.IsRecording() {
+			return container.Audio.HandleStopRecording()
+		}
+		return container.Audio.HandleStartRecording()
+	}
+}
+
+func (cw *CallbackWirer) makeShowConfigCallback(container *ServiceContainer) func() error {
+	return func() error {
+		if container == nil || container.UI == nil {
+			return fmt.Errorf("UI service not available")
+		}
+		return container.UI.ShowConfigFile()
+	}
+}
+
+func (cw *CallbackWirer) makeShowAboutCallback(container *ServiceContainer) func() error {
+	return func() error {
+		if container == nil || container.UI == nil {
+			return fmt.Errorf("UI service not available")
+		}
+		return container.UI.ShowAboutPage()
+	}
+}
+
+func (cw *CallbackWirer) makeResetToDefaultsCallback(container *ServiceContainer) func() error {
+	return func() error {
+		if container == nil || container.Config == nil {
+			return fmt.Errorf("config service not available")
+		}
+
+		if err := container.Config.ResetToDefaults(); err != nil {
+			return err
+		}
+
+		return cw.reloadHotkeysFromConfig(container)
+	}
+}
+
+func (cw *CallbackWirer) makeRecorderSelectionCallback(container *ServiceContainer) func(string) error {
+	return func(method string) error {
+		if container == nil || container.Config == nil {
+			return fmt.Errorf("config service not available")
+		}
+		if err := container.Config.UpdateRecordingMethod(method); err != nil {
+			return err
+		}
+		if audioSvc, ok := container.Audio.(*AudioService); ok {
+			audioSvc.clearSession()
+		}
+		cw.updateUISettings(container)
+		return nil
+	}
+}
+
+func (cw *CallbackWirer) makeLanguageCallback(container *ServiceContainer) func(string) error {
+	return func(language string) error {
+		if container == nil || container.Config == nil {
+			return fmt.Errorf("config service not available")
+		}
+		return container.Config.UpdateLanguage(language)
+	}
+}
+
+func (cw *CallbackWirer) makeToggleNotificationsCallback(container *ServiceContainer) func() error {
+	return func() error {
+		if container == nil || container.Config == nil {
+			return fmt.Errorf("config service not available")
+		}
+		if err := container.Config.ToggleWorkflowNotifications(); err != nil {
+			return err
+		}
+
+		if container.UI != nil {
+			enabled := cw.getNotificationStatus(container)
+			container.UI.ShowNotification("Workflow Notifications", "Now "+enabled)
+		}
+		return nil
+	}
+}
+
+func (cw *CallbackWirer) makeOutputModeCallback(container *ServiceContainer) func(string) error {
+	return func(mode string) error {
+		if container == nil || container.Config == nil || container.IO == nil {
+			return fmt.Errorf("services not available")
+		}
+		if err := container.Config.UpdateOutputMode(mode); err != nil {
+			return err
+		}
+		if err := container.IO.SetOutputMethod(mode); err != nil {
+			return err
+		}
+		cw.updateUISettings(container)
+		return nil
+	}
+}
+
+func (cw *CallbackWirer) makeGetOutputToolsCallback(container *ServiceContainer) func() (string, string) {
+	return func() (clipboardTool, typeTool string) {
 		if container == nil || container.IO == nil {
 			return "unknown", "unknown"
 		}
@@ -184,83 +175,116 @@ func (cw *CallbackWirer) Wire(container *ServiceContainer, components *Component
 			return ioSvc.GetOutputToolNames()
 		}
 		return "unknown", "unknown"
-	})
+	}
+}
 
-	// Capture once support capability
-	components.TrayManager.SetCaptureOnceSupport(func() bool {
+func (cw *CallbackWirer) makeCaptureOnceSupportCallback(container *ServiceContainer) func() bool {
+	return func() bool {
 		if container == nil || container.Hotkeys == nil {
 			return false
 		}
 		return container.Hotkeys.SupportsCaptureOnce()
-	})
-
-	// Force UI update after callback is set
-	if container != nil && container.Config != nil {
-		if cfgSvc, ok := container.Config.(*ConfigService); ok && cfgSvc != nil {
-			if cfg := cfgSvc.GetConfig(); cfg != nil {
-				components.TrayManager.UpdateSettings(cfg)
-			}
-		}
 	}
+}
 
-	// Hotkeys rebind wiring
-	components.TrayManager.SetHotkeyRebindAction(func(action string) error {
+func (cw *CallbackWirer) makeHotkeyRebindCallback(container *ServiceContainer) func(string) error {
+	return func(action string) error {
 		if container == nil || container.UI == nil || container.Config == nil || container.Hotkeys == nil {
 			return fmt.Errorf("services not available")
 		}
 
-		// Show prompt and capture through provider
-		if container.UI != nil {
-			container.UI.ShowNotification("Rebind Hotkey", "Press new hotkey… (Esc to cancel)")
-		}
+		container.UI.ShowNotification("Rebind Hotkey", "Press new hotkey… (Esc to cancel)")
+
 		combo, err := container.Hotkeys.CaptureOnce(3000)
 		if err != nil || strings.TrimSpace(combo) == "" {
-			if container.UI != nil {
-				container.UI.ShowNotification("Rebind Hotkey", "Cancelled or timeout")
-			}
+			container.UI.ShowNotification("Rebind Hotkey", "Cancelled or timeout")
 			return nil
 		}
 
-		// Persist in config
 		if err := container.Config.UpdateHotkey(action, combo); err != nil {
 			return err
 		}
 
-		// Reload hotkeys in manager from updated config
-		cfgProvider := func() adapters.HotkeyConfig {
-			if cfgSvc, ok := container.Config.(*ConfigService); ok && cfgSvc != nil {
-				if cfg := cfgSvc.GetConfig(); cfg != nil {
-					return adapters.NewConfigAdapter(cfg.Hotkeys.StartRecording, cfg.Hotkeys.Provider).
-						WithAdditionalHotkeys(
-							"",
-							cfg.Hotkeys.ShowConfig,
-							cfg.Hotkeys.ResetToDefaults,
-						)
-				}
-			}
-			return adapters.NewConfigAdapter("", "auto")
-		}
-
-		// Ensure callbacks preserved
-		if err := container.Hotkeys.ReloadFromConfig(
-			func() error { return container.Audio.HandleStartRecording() },
-			func() error { return container.Audio.HandleStopRecording() },
-			cfgProvider,
-		); err != nil {
+		if err := cw.reloadHotkeysFromConfig(container); err != nil {
 			return err
 		}
 
-		// Notify user about successful rebind
-		if container.UI != nil {
-			title := "Hotkey Updated"
-			msg := fmt.Sprintf("%s -> %s", action, combo)
-			container.UI.ShowNotification(title, msg)
-		}
+		container.UI.ShowNotification("Hotkey Updated", fmt.Sprintf("%s -> %s", action, combo))
 		return nil
-	})
+	}
+}
 
-	// Ensure Quit exits app cleanly
-	components.TrayManager.SetExitAction(func() {
-		_ = syscall.Kill(os.Getpid(), syscall.SIGTERM)
-	})
+// Helper methods to reduce duplication
+func (cw *CallbackWirer) reloadHotkeysFromConfig(container *ServiceContainer) error {
+	if container.Hotkeys == nil {
+		return nil
+	}
+
+	cfgProvider := cw.makeConfigProvider(container)
+	return container.Hotkeys.ReloadFromConfig(
+		func() error { return container.Audio.HandleStartRecording() },
+		func() error { return container.Audio.HandleStopRecording() },
+		cfgProvider,
+	)
+}
+
+func (cw *CallbackWirer) makeConfigProvider(container *ServiceContainer) func() adapters.HotkeyConfig {
+	return func() adapters.HotkeyConfig {
+		cfgSvc, ok := container.Config.(*ConfigService)
+		if !ok || cfgSvc == nil {
+			return adapters.NewConfigAdapter("", "auto")
+		}
+
+		cfg := cfgSvc.GetConfig()
+		if cfg == nil {
+			return adapters.NewConfigAdapter("", "auto")
+		}
+
+		return adapters.NewConfigAdapter(cfg.Hotkeys.StartRecording, cfg.Hotkeys.Provider).
+			WithAdditionalHotkeys("", cfg.Hotkeys.ShowConfig, cfg.Hotkeys.ResetToDefaults)
+	}
+}
+
+func (cw *CallbackWirer) updateUISettings(container *ServiceContainer) {
+	uiSvc, ok := container.UI.(*UIService)
+	if !ok || uiSvc == nil {
+		return
+	}
+
+	cfgSvc, ok := container.Config.(*ConfigService)
+	if !ok || cfgSvc == nil {
+		return
+	}
+
+	if cfg := cfgSvc.GetConfig(); cfg != nil {
+		uiSvc.UpdateSettings(cfg)
+	}
+}
+
+func (cw *CallbackWirer) updateTraySettings(container *ServiceContainer, trayManager interface{ UpdateSettings(*config.Config) }) {
+	if container == nil || container.Config == nil {
+		return
+	}
+
+	cfgSvc, ok := container.Config.(*ConfigService)
+	if !ok || cfgSvc == nil {
+		return
+	}
+
+	if cfg := cfgSvc.GetConfig(); cfg != nil {
+		trayManager.UpdateSettings(cfg)
+	}
+}
+
+func (cw *CallbackWirer) getNotificationStatus(container *ServiceContainer) string {
+	cfgSvc, ok := container.Config.(*ConfigService)
+	if !ok || cfgSvc == nil {
+		return "disabled"
+	}
+
+	cfg := cfgSvc.GetConfig()
+	if cfg != nil && cfg.Notifications.EnableWorkflowNotifications {
+		return "enabled"
+	}
+	return "disabled"
 }

--- a/internal/services/hotkey_service_test.go
+++ b/internal/services/hotkey_service_test.go
@@ -11,157 +11,160 @@ import (
 	"github.com/AshBuk/speak-to-ai/tests/mocks"
 )
 
-func TestHotkeyService(t *testing.T) {
+func TestHotkeyService_NewHotkeyService(t *testing.T) {
 	mockLogger := testutils.NewMockLogger()
+	mockManager := &mocks.MockHotkeyManager{}
 
-	t.Run("NewHotkeyService", func(t *testing.T) {
-		mockManager := &mocks.MockHotkeyManager{}
-		service := NewHotkeyService(mockLogger, mockManager)
+	service := NewHotkeyService(mockLogger, mockManager)
 
-		if service == nil {
-			t.Fatal("NewHotkeyService returned nil")
+	if service == nil {
+		t.Fatal("NewHotkeyService returned nil")
+	}
+	if service.logger != mockLogger {
+		t.Error("Logger not set correctly")
+	}
+	if service.hotkeyManager != mockManager {
+		t.Error("Hotkey manager not set correctly")
+	}
+}
+
+func TestHotkeyService_RegisterHotkeys_Success(t *testing.T) {
+	mockLogger := testutils.NewMockLogger()
+	mockManager := &mocks.MockHotkeyManager{}
+
+	service := NewHotkeyService(mockLogger, mockManager)
+
+	if err := service.RegisterHotkeys(); err != nil {
+		t.Errorf("RegisterHotkeys failed: %v", err)
+	}
+	if !mockManager.WasStartCalled() {
+		t.Error("Hotkey manager Start method was not called")
+	}
+}
+
+func TestHotkeyService_RegisterHotkeys_Error(t *testing.T) {
+	mockLogger := testutils.NewMockLogger()
+	expectedError := errors.New("hotkey registration failed")
+	mockManager := &mocks.MockHotkeyManager{}
+	mockManager.SetStartError(expectedError)
+
+	service := NewHotkeyService(mockLogger, mockManager)
+
+	if err := service.RegisterHotkeys(); err != expectedError {
+		t.Errorf("Expected error %v, got %v", expectedError, err)
+	}
+}
+
+func TestHotkeyService_RegisterHotkeys_NoManager(t *testing.T) {
+	mockLogger := testutils.NewMockLogger()
+	service := NewHotkeyService(mockLogger, nil)
+
+	if err := service.RegisterHotkeys(); err == nil {
+		t.Error("RegisterHotkeys should fail when hotkey manager is nil")
+	}
+}
+
+func TestHotkeyService_UnregisterHotkeys_Success(t *testing.T) {
+	mockLogger := testutils.NewMockLogger()
+	mockManager := &mocks.MockHotkeyManager{}
+
+	service := NewHotkeyService(mockLogger, mockManager)
+
+	if err := service.UnregisterHotkeys(); err != nil {
+		t.Errorf("UnregisterHotkeys failed: %v", err)
+	}
+	if !mockManager.WasStopCalled() {
+		t.Error("Hotkey manager Stop method was not called")
+	}
+}
+
+func TestHotkeyService_UnregisterHotkeys_NoManager(t *testing.T) {
+	mockLogger := testutils.NewMockLogger()
+	service := NewHotkeyService(mockLogger, nil)
+
+	if err := service.UnregisterHotkeys(); err != nil {
+		t.Errorf("UnregisterHotkeys should not fail when hotkey manager is nil: %v", err)
+	}
+}
+
+func TestHotkeyService_SetupHotkeyCallbacks_Success(t *testing.T) {
+	mockLogger := testutils.NewMockLogger()
+	mockManager := &mocks.MockHotkeyManager{}
+	service := NewHotkeyService(mockLogger, mockManager)
+
+	// Create test callback functions
+	var callbacksCalled []string
+	startRecording := func() error { callbacksCalled = append(callbacksCalled, "startRecording"); return nil }
+	stopRecording := func() error { callbacksCalled = append(callbacksCalled, "stopRecording"); return nil }
+	showConfig := func() error { callbacksCalled = append(callbacksCalled, "showConfig"); return nil }
+	reloadConfig := func() error { callbacksCalled = append(callbacksCalled, "reloadConfig"); return nil }
+
+	err := service.SetupHotkeyCallbacks(
+		startRecording, stopRecording,
+		showConfig, reloadConfig,
+	)
+	if err != nil {
+		t.Errorf("SetupHotkeyCallbacks failed: %v", err)
+	}
+
+	// Verify RegisterCallbacks was called
+	if !mockManager.WereCallbacksRegistered() {
+		t.Error("RegisterCallbacks was not called")
+	}
+
+	// Verify all hotkey actions were registered
+	expectedActions := []string{"show_config", "reset_to_defaults"}
+	for _, action := range expectedActions {
+		if !mockManager.WasHotkeyActionRegistered(action) {
+			t.Errorf("RegisterHotkeyAction was not called for action: %s", action)
 		}
-		if service.logger != mockLogger {
-			t.Error("Logger not set correctly")
-		}
-		if service.hotkeyManager != mockManager {
-			t.Error("Hotkey manager not set correctly")
-		}
-	})
+	}
 
-	t.Run("RegisterHotkeys_Success", func(t *testing.T) {
-		mockManager := &mocks.MockHotkeyManager{}
-		service := NewHotkeyService(mockLogger, mockManager)
+	// Test that callbacks work
+	mockManager.TriggerCallback("startRecording")
+	mockManager.TriggerCallback("showConfig")
 
-		err := service.RegisterHotkeys()
-		if err != nil {
-			t.Errorf("RegisterHotkeys failed: %v", err)
-		}
-		if !mockManager.WasStartCalled() {
-			t.Error("Hotkey manager Start method was not called")
-		}
-	})
+	if len(callbacksCalled) != 2 {
+		t.Errorf("Expected 2 callbacks to be called, got %d", len(callbacksCalled))
+	}
+	if callbacksCalled[0] != "startRecording" || callbacksCalled[1] != "showConfig" {
+		t.Errorf("Unexpected callbacks called: %v", callbacksCalled)
+	}
+}
 
-	t.Run("RegisterHotkeys_Error", func(t *testing.T) {
-		expectedError := errors.New("hotkey registration failed")
-		mockManager := &mocks.MockHotkeyManager{}
-		mockManager.SetStartError(expectedError)
-		service := NewHotkeyService(mockLogger, mockManager)
+func TestHotkeyService_SetupHotkeyCallbacks_NoManager(t *testing.T) {
+	mockLogger := testutils.NewMockLogger()
+	service := NewHotkeyService(mockLogger, nil)
 
-		err := service.RegisterHotkeys()
-		if err != expectedError {
-			t.Errorf("Expected error %v, got %v", expectedError, err)
-		}
-	})
+	err := service.SetupHotkeyCallbacks(
+		func() error { return nil },
+		func() error { return nil },
+		func() error { return nil },
+		func() error { return nil },
+	)
+	if err == nil {
+		t.Error("SetupHotkeyCallbacks should fail when hotkey manager is nil")
+	}
+}
 
-	t.Run("RegisterHotkeys_NoManager", func(t *testing.T) {
-		service := NewHotkeyService(mockLogger, nil)
+func TestHotkeyService_Shutdown_Success(t *testing.T) {
+	mockLogger := testutils.NewMockLogger()
+	mockManager := &mocks.MockHotkeyManager{}
+	service := NewHotkeyService(mockLogger, mockManager)
 
-		err := service.RegisterHotkeys()
-		if err == nil {
-			t.Error("RegisterHotkeys should fail when hotkey manager is nil")
-		}
-	})
+	if err := service.Shutdown(); err != nil {
+		t.Errorf("Shutdown failed: %v", err)
+	}
+	if !mockManager.WasStopCalled() {
+		t.Error("Hotkey manager Stop method was not called during shutdown")
+	}
+}
 
-	t.Run("UnregisterHotkeys_Success", func(t *testing.T) {
-		mockManager := &mocks.MockHotkeyManager{}
-		service := NewHotkeyService(mockLogger, mockManager)
+func TestHotkeyService_Shutdown_NoManager(t *testing.T) {
+	mockLogger := testutils.NewMockLogger()
+	service := NewHotkeyService(mockLogger, nil)
 
-		err := service.UnregisterHotkeys()
-		if err != nil {
-			t.Errorf("UnregisterHotkeys failed: %v", err)
-		}
-		if !mockManager.WasStopCalled() {
-			t.Error("Hotkey manager Stop method was not called")
-		}
-	})
-
-	t.Run("UnregisterHotkeys_NoManager", func(t *testing.T) {
-		service := NewHotkeyService(mockLogger, nil)
-
-		err := service.UnregisterHotkeys()
-		if err != nil {
-			t.Errorf("UnregisterHotkeys should not fail when hotkey manager is nil: %v", err)
-		}
-	})
-
-	t.Run("SetupHotkeyCallbacks_Success", func(t *testing.T) {
-		mockManager := &mocks.MockHotkeyManager{}
-		service := NewHotkeyService(mockLogger, mockManager)
-
-		// Create test callback functions
-		var callbacksCalled []string
-		startRecording := func() error { callbacksCalled = append(callbacksCalled, "startRecording"); return nil }
-		stopRecording := func() error { callbacksCalled = append(callbacksCalled, "stopRecording"); return nil }
-		showConfig := func() error { callbacksCalled = append(callbacksCalled, "showConfig"); return nil }
-		reloadConfig := func() error { callbacksCalled = append(callbacksCalled, "reloadConfig"); return nil }
-
-		err := service.SetupHotkeyCallbacks(
-			startRecording, stopRecording,
-			showConfig, reloadConfig,
-		)
-		if err != nil {
-			t.Errorf("SetupHotkeyCallbacks failed: %v", err)
-		}
-
-		// Verify RegisterCallbacks was called
-		if !mockManager.WereCallbacksRegistered() {
-			t.Error("RegisterCallbacks was not called")
-		}
-
-		// Verify all hotkey actions were registered
-		expectedActions := []string{"show_config", "reset_to_defaults"}
-		for _, action := range expectedActions {
-			if !mockManager.WasHotkeyActionRegistered(action) {
-				t.Errorf("RegisterHotkeyAction was not called for action: %s", action)
-			}
-		}
-
-		// Test that callbacks work
-		mockManager.TriggerCallback("startRecording")
-		mockManager.TriggerCallback("showConfig")
-
-		if len(callbacksCalled) != 2 {
-			t.Errorf("Expected 2 callbacks to be called, got %d", len(callbacksCalled))
-		}
-		if callbacksCalled[0] != "startRecording" || callbacksCalled[1] != "showConfig" {
-			t.Errorf("Unexpected callbacks called: %v", callbacksCalled)
-		}
-	})
-
-	t.Run("SetupHotkeyCallbacks_NoManager", func(t *testing.T) {
-		service := NewHotkeyService(mockLogger, nil)
-
-		err := service.SetupHotkeyCallbacks(
-			func() error { return nil },
-			func() error { return nil },
-			func() error { return nil },
-			func() error { return nil },
-		)
-		if err == nil {
-			t.Error("SetupHotkeyCallbacks should fail when hotkey manager is nil")
-		}
-	})
-
-	t.Run("Shutdown_Success", func(t *testing.T) {
-		mockManager := &mocks.MockHotkeyManager{}
-		service := NewHotkeyService(mockLogger, mockManager)
-
-		err := service.Shutdown()
-		if err != nil {
-			t.Errorf("Shutdown failed: %v", err)
-		}
-		if !mockManager.WasStopCalled() {
-			t.Error("Hotkey manager Stop method was not called during shutdown")
-		}
-	})
-
-	t.Run("Shutdown_NoManager", func(t *testing.T) {
-		service := NewHotkeyService(mockLogger, nil)
-
-		err := service.Shutdown()
-		if err != nil {
-			t.Errorf("Shutdown should not fail when hotkey manager is nil: %v", err)
-		}
-	})
+	if err := service.Shutdown(); err != nil {
+		t.Errorf("Shutdown should not fail when hotkey manager is nil: %v", err)
+	}
 }

--- a/tests/integration/audio_integration_test.go
+++ b/tests/integration/audio_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 // Copyright (c) 2025 Asher Buk
 // SPDX-License-Identifier: MIT

--- a/tests/integration/end_to_end_test.go
+++ b/tests/integration/end_to_end_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 // Copyright (c) 2025 Asher Buk
 // SPDX-License-Identifier: MIT

--- a/tests/integration/goroutine_lifecycle_test.go
+++ b/tests/integration/goroutine_lifecycle_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 // Copyright (c) 2025 Asher Buk
 // SPDX-License-Identifier: MIT

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 // Copyright (c) 2025 Asher Buk
 // SPDX-License-Identifier: MIT

--- a/tests/integration/notification_integration_test.go
+++ b/tests/integration/notification_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 //go:build integration
-// +build integration
 
 package integration
 

--- a/tests/integration/platform_integration_test.go
+++ b/tests/integration/platform_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 // Copyright (c) 2025 Asher Buk
 // SPDX-License-Identifier: MIT


### PR DESCRIPTION
 - Reduces cyclomatic complexity across the codebase and enables automated complexity checking in CI pipeline.
 - Table-driven tests (yaml_loader_test.go, ui_test.go, end_to_end_test.go, manager_provider_test.go) were left unchanged because this pattern is idiomatic in Go. The complexity naturally increases with the number of test cases and their validations, but splitting them would reduce readability