### PR TITLE
Refactor/dip compliance

### DIFF
--- a/hotkeys/interfaces/provider.go
+++ b/hotkeys/interfaces/provider.go
@@ -17,6 +17,8 @@ type KeyboardEventProvider interface {
 	IsSupported() bool
 	// Capture a single hotkey combination within a given timeout
 	CaptureOnce(timeout time.Duration) (string, error)
+	// Check if the provider supports one-shot hotkey capture
+	SupportsCaptureOnce() bool
 }
 
 // Represents a hotkey combination

--- a/hotkeys/manager/provider_fallback.go
+++ b/hotkeys/manager/provider_fallback.go
@@ -80,9 +80,8 @@ func startFallbackAfterRegistration(h *HotkeyManager, startErr error) error {
 	if isAppImage {
 		h.logger.Info("AppImage detected - allowing evdev fallback for better hotkey compatibility")
 	}
-	// Only fall back from DBus to evdev if evdev is supported
-	switch h.provider.(type) {
-	case *providers.DbusKeyboardProvider:
+	// Only fall back to evdev if current provider doesn't support capture (i.e., D-Bus)
+	if !h.provider.SupportsCaptureOnce() {
 		fallback := providers.NewEvdevKeyboardProvider(h.logger)
 		if fallback != nil && fallback.IsSupported() {
 			h.logger.Info("Falling back to evdev keyboard provider")

--- a/hotkeys/mocks/mock_provider.go
+++ b/hotkeys/mocks/mock_provider.go
@@ -119,6 +119,9 @@ func (m *MockHotkeyProvider) CaptureOnce(_ time.Duration) (string, error) {
 	return "alt+r", nil
 }
 
+// SupportsCaptureOnce returns true for mock provider
+func (m *MockHotkeyProvider) SupportsCaptureOnce() bool { return true }
+
 // Test helper methods
 
 // SetSupported configures whether the provider is supported

--- a/hotkeys/providers/dbus_provider.go
+++ b/hotkeys/providers/dbus_provider.go
@@ -139,6 +139,9 @@ func (p *DbusKeyboardProvider) RegisterHotkey(hotkey string, callback func() err
 	return nil
 }
 
+// SupportsCaptureOnce returns false as D-Bus GlobalShortcuts portal doesn't support one-shot capture
+func (p *DbusKeyboardProvider) SupportsCaptureOnce() bool { return false }
+
 // Return an error as this provider does not support capture-once functionality
 func (p *DbusKeyboardProvider) CaptureOnce(timeout time.Duration) (string, error) {
 	return "", fmt.Errorf("captureOnce not supported in dbus provider")

--- a/hotkeys/providers/dummy_provider.go
+++ b/hotkeys/providers/dummy_provider.go
@@ -73,6 +73,9 @@ func (p *DummyKeyboardProvider) RegisterHotkey(hotkey string, callback func() er
 	return nil
 }
 
+// SupportsCaptureOnce returns false as dummy provider has no real functionality
+func (p *DummyKeyboardProvider) SupportsCaptureOnce() bool { return false }
+
 // Return an error as this functionality is not supported
 func (p *DummyKeyboardProvider) CaptureOnce(timeout time.Duration) (string, error) {
 	return "", fmt.Errorf("captureOnce not supported in dummy provider")

--- a/hotkeys/providers/evdev_provider.go
+++ b/hotkeys/providers/evdev_provider.go
@@ -400,6 +400,9 @@ func (cs *captureSession) cleanup() {
 	}
 }
 
+// SupportsCaptureOnce returns true as evdev supports one-shot hotkey capture
+func (p *EvdevKeyboardProvider) SupportsCaptureOnce() bool { return true }
+
 // Start a short-lived capture session to get a single hotkey combination
 // Note: This creates a fresh isolated session, not tied to the regular provider lifecycle
 func (p *EvdevKeyboardProvider) CaptureOnce(timeout time.Duration) (string, error) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -118,13 +118,10 @@ func (a *App) initializeServices(cfg *config.Config, cfgFilePath string) error {
 	return nil
 }
 
-// Establish communication channels between services
-// Manual Dependency Injection - wire services together
+// setupServiceDependencies is a no-op placeholder for future cross-service wiring
+// Note: All dependency injection is handled in FactoryAssembler.Assemble()
 func (a *App) setupServiceDependencies() {
-	// Example: AudioService needs UIService for status updates and IOService for output
-	if audioSvc, ok := a.Services.Audio.(*services.AudioService); ok {
-		audioSvc.SetDependencies(a.Services.UI, a.Services.IO)
-	}
+	// Wiring done in factory_assembler.go (Step 4: Late wiring)
 }
 
 // Connect hotkey manager events to their corresponding handler methods

--- a/internal/app/ipc.go
+++ b/internal/app/ipc.go
@@ -118,27 +118,19 @@ func (a *App) ipcHandleLastTranscript(ipc.Request) (ipc.Response, error) {
 }
 
 // waitForTranscription Blocks until transcription ready or timeout expires
-// Type assertion: accesses IOService.WaitForTranscription (not in interface)
 // Used by ipcHandleStopRecording to provide synchronous CLI response
 func (a *App) waitForTranscription(timeout time.Duration) (string, error) {
 	if a.Services == nil || a.Services.IO == nil {
 		return "", fmt.Errorf("io service not available")
 	}
-	if ioSvc, ok := a.Services.IO.(*services.IOService); ok && ioSvc != nil {
-		return ioSvc.WaitForTranscription(timeout)
-	}
-	return "", fmt.Errorf("io service does not support transcription wait")
+	return a.Services.IO.WaitForTranscription(timeout)
 }
 
 // getLastTranscript Returns cached transcript without waiting
-// Type assertion: accesses AudioService.GetLastTranscript (not in interface)
 // Used by status/last-transcript commands for immediate response
 func (a *App) getLastTranscript() string {
 	if a.Services == nil || a.Services.Audio == nil {
 		return ""
 	}
-	if audioSvc, ok := a.Services.Audio.(*services.AudioService); ok && audioSvc != nil {
-		return audioSvc.GetLastTranscript()
-	}
-	return ""
+	return a.Services.Audio.GetLastTranscript()
 }

--- a/internal/services/interfaces.go
+++ b/internal/services/interfaces.go
@@ -4,6 +4,8 @@
 package services
 
 import (
+	"time"
+
 	"github.com/AshBuk/speak-to-ai/audio/processing"
 	"github.com/AshBuk/speak-to-ai/config"
 	"github.com/AshBuk/speak-to-ai/hotkeys/adapters"
@@ -18,6 +20,9 @@ type AudioServiceInterface interface {
 
 	// Session management
 	ClearSession()
+
+	// Transcript access
+	GetLastTranscript() string
 
 	// TODO: Next feature - VAD implementation
 	// VAD (Voice Activity Detection) operations
@@ -56,6 +61,7 @@ type IOServiceInterface interface {
 	// Transcription synchronization
 	BeginTranscription()
 	CompleteTranscription(result string)
+	WaitForTranscription(timeout time.Duration) (string, error)
 
 	// Debug info
 	GetOutputToolNames() (clipboardTool, typeTool string)

--- a/tests/mocks/services.go
+++ b/tests/mocks/services.go
@@ -4,6 +4,8 @@
 package mocks
 
 import (
+	"time"
+
 	"github.com/AshBuk/speak-to-ai/config"
 	"github.com/AshBuk/speak-to-ai/hotkeys/adapters"
 )
@@ -23,6 +25,7 @@ func (m *MockAudioService) HandleStartRecording() error { return nil }
 func (m *MockAudioService) HandleStopRecording() error  { return nil }
 func (m *MockAudioService) IsRecording() bool           { return false }
 func (m *MockAudioService) ClearSession()               {}
+func (m *MockAudioService) GetLastTranscript() string   { return "" }
 
 // TODO: Next feature - VAD implementation
 // func (m *MockAudioService) HandleStartVADRecording() error                  { return nil }
@@ -68,13 +71,14 @@ func (m *MockIOService) Shutdown() error {
 	return m.shutdownError
 }
 
-func (m *MockIOService) OutputText(text string) error         { return nil }
-func (m *MockIOService) SetOutputMethod(method string) error  { return nil }
-func (m *MockIOService) BeginTranscription()                  {}
-func (m *MockIOService) CompleteTranscription(result string)  {}
-func (m *MockIOService) GetOutputToolNames() (string, string) { return "mock-clipboard", "mock-typing" }
-func (m *MockIOService) StartWebSocketServer() error          { return nil }
-func (m *MockIOService) StopWebSocketServer() error           { return nil }
+func (m *MockIOService) OutputText(text string) error                               { return nil }
+func (m *MockIOService) SetOutputMethod(method string) error                        { return nil }
+func (m *MockIOService) BeginTranscription()                                        {}
+func (m *MockIOService) CompleteTranscription(result string)                        {}
+func (m *MockIOService) WaitForTranscription(timeout time.Duration) (string, error) { return "", nil }
+func (m *MockIOService) GetOutputToolNames() (string, string)                       { return "mock-clipboard", "mock-typing" }
+func (m *MockIOService) StartWebSocketServer() error                                { return nil }
+func (m *MockIOService) StopWebSocketServer() error                                 { return nil }
 
 // Test helper methods
 func (m *MockIOService) WasShutdownCalled() bool { return m.shutdownCalled }


### PR DESCRIPTION
## Summary

Continuation of DIP compliance work. Eliminates remaining type assertions by extending interfaces.

### Changes
- **KeyboardEventProvider**: Add `SupportsCaptureOnce()` method
- **AudioServiceInterface**: Add `GetLastTranscript()` method  
- **IOServiceInterface**: Add `WaitForTranscription()` method
- Remove duplicate service wiring in `App.setupServiceDependencies()`

### Type assertions removed
| File | Before | After |
|------|--------|-------|
| manager.go | `provider.(*EvdevKeyboardProvider)` | `provider.SupportsCaptureOnce()` |
| provider_fallback.go | `switch provider.(type)` | `!provider.SupportsCaptureOnce()` |
| ipc.go | `IO.(*IOService)` | `IO.WaitForTranscription()` |
| ipc.go | `Audio.(*AudioService)` | `Audio.GetLastTranscript()` |