### PR TITLE
Goroutines/per component ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.1] - 2025-12-24
+
+### Improvements
+- **Hotkey rebind optimization:** Reduced latency from ~1-2s to ~100ms ([#60](https://github.com/AshBuk/speak-to-ai/pull/60))
+- **Deterministic shutdown:** Per-component goroutine ownership with WaitGroup tracking ([#60](https://github.com/AshBuk/speak-to-ai/pull/60))
+- **Architecture:** Remove type assertions, use interfaces directly (DIP compliance) ([#58](https://github.com/AshBuk/speak-to-ai/pull/58), [#59](https://github.com/AshBuk/speak-to-ai/pull/59))
+- Drop Flatpak support. Details: [#57](https://github.com/AshBuk/speak-to-ai/pull/57)
+
+---
 ## [1.4.0] - 2025-12-15
 
 ### Features
@@ -25,7 +34,7 @@ All notable changes to this project will be documented in this file.
 - Includes: comments, formatting, code style, and light stylistic refactoring.
 - Excludes: any functional changes
 
-Based on #55.
+Based on [#55](https://github.com/AshBuk/speak-to-ai/pull/55).
 
 ---
 ## [1.3.2] - 2025-11-13

--- a/README.md
+++ b/README.md
@@ -46,9 +46,24 @@ https://github.com/user-attachments/assets/e8448f73-57f2-46dc-98f9-e36f685a6587
 - **Portable**: AppImage package
 - **Cross-platform support** for X11 and Wayland
 - **Linux DEs**: native integration with GNOME, KDE, and others
-- **Voice typing or clipboard mode** 
+- **Voice typing or clipboard mode**
 - **Flexible audio recording**: arecord (ALSA) or ffmpeg (PulseAudio/PipeWire), see [audio pipeline](docs/AUDIO_PIPELINE_DIAGRAM.txt)
 - **Multi-language support, custom hotkey binding, visual notifications**
+
+## Beyond Minimalism
+
+Intuitive minimalist UX, **robust STT infrastructure**. A foundation for voice-controlled automation:
+
+- **Dual API**: Unix socket IPC + WebSocket — script locally or integrate remotely
+- **Interface-driven**: 50+ contracts — swap STT engines, add I/O methods, extend hotkey providers
+- **Daemon + CLI**: background hub + stateless commands — perfect for IoT pipelines
+- **Graceful degradation**: provider fallbacks, optional components, no crashes
+
+```bash
+# Voice command → smart home action
+transcript=$(speak-to-ai stop-recording | jq -r '.data.transcript')
+[[ "$transcript" == *"lights off"* ]] && curl -X POST http://hub/lights/off
+```
 
 ## ✦ Installation
 

--- a/internal/assets/about.html
+++ b/internal/assets/about.html
@@ -197,8 +197,8 @@
 
     <div class="section">
         <div class="planned-features"></div>
-        <p><strong>Current version: 1.4.0</strong></p>
-        <p><strong>New:</strong> Full multi-language support with all 99 Whisper languages</p>
+        <p><strong>Current version: 1.4.1</strong></p>
+        <p><strong>New:</strong> Optimized hotkey rebind, deterministic shutdown</p>
         <p><strong>Next feature:</strong> VAD (Voice Activity Detection) with enable/disable option and sensitivity settings via menu</p>
     </div>
 

--- a/io.github.ashbuk.speak-to-ai.appdata.xml
+++ b/io.github.ashbuk.speak-to-ai.appdata.xml
@@ -47,6 +47,16 @@
     <binary>speak-to-ai</binary>
   </provides>
   <releases>
+    <release version="1.4.1" date="2025-12-25">
+      <description>
+        <p>Performance and architecture improvements.</p>
+        <ul>
+          <li>Hotkey rebind optimization: latency reduced from ~1-2s to ~100ms</li>
+          <li>Deterministic shutdown with per-component goroutine ownership</li>
+          <li>Architecture cleanup: DIP compliance, removed Flatpak support</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.4.0" date="2025-12-15">
       <description>
         <p>Full multi-language support with all 99 Whisper-supported languages.</p>
@@ -57,25 +67,8 @@
         </ul>
       </description>
     </release>
-    <release version="1.3.4" date="2025-12-07">
-      <description>
-        <p>Security enhancement: Added SAST security scanning with gosec for continuous security monitoring.</p>
-        <ul>
-          <li>gosec integration: Automated security scans on every PR with SARIF reports</li>
-          <li>Zero vulnerabilities: Current scan shows 0 security issues across 10,241 lines of code</li>
-          <li>CI/CD security: Enhanced GitHub Actions workflow with CodeQL integration</li>
-        </ul>
-      </description>
-    </release>
-    <release version="1.3.3" date="2025-11-27">
-      <description>
-        <p>Improving long-term project maintainability: Key design components are now clarified so developers can understand the flow more quickly.</p>
-        <ul>
-          <li>Includes: comments, formatting, code style, and light stylistic refactoring.</li>
-          <li>Excludes: any functional changes</li>
-        </ul>
-      </description>
-    </release>
+    <release version="1.3.4" date="2025-12-07"/>
+    <release version="1.3.3" date="2025-11-27"/>
     <release version="1.3.2" date="2025-11-13"/>
     <release version="1.3.1" date="2025-10-31"/>
     <release version="1.3.0" date="2025-10-29"/>

--- a/websocket/message_handler.go
+++ b/websocket/message_handler.go
@@ -35,11 +35,12 @@ func (s *WebSocketServer) processMessages(conn *websocket.Conn) {
 			continue
 		}
 		// Process message based on type
+		// Synchronous handling per-connection provides natural backpressure
 		switch msg.Type {
 		case "start-recording":
-			go s.handleStartRecording(conn, msg.RequestID)
+			s.handleStartRecording(conn, msg.RequestID)
 		case "stop-recording":
-			go s.handleStopRecording(conn, msg.RequestID)
+			s.handleStopRecording(conn, msg.RequestID)
 		case "ping":
 			s.sendMessage(conn, "pong", nil)
 		default:


### PR DESCRIPTION
## Per-Component Goroutine Ownership & Evdev Optimization

Implements deterministic shutdown semantics and optimizes hotkey rebind latency.

### Changes

**Goroutine Ownership**
- `AudioService`: WaitGroup tracks background transcription; Shutdown waits with 5s timeout
- `IPC Server`: WaitGroup tracks acceptLoop and connection handlers; Stop waits with 2s timeout
- `WebSocket`: Synchronous message handling per-connection (natural backpressure)
- `whisper/engine`: Documented fake-cancellation semantics (CGO limitation)

**Evdev Hotkey Rebind Optimization**
- Non-blocking `ReadOne()` mode eliminates blocking on `Close()`
- Stop/cleanup timeout reduced from 500ms → 50ms
- Removed redundant `IsSupported()` check in `CaptureOnce()` flow

### Performance Impact
Hotkey rebind latency: **~1-2s → ~100ms**

### Testing
- All existing hotkey/provider tests pass
- `TestEvdevStopTimeout`: 544ms → 88ms
- `TestEvdevRapidRestarts`: 6.1s → 3.3s