### PR TITLE
Deploy/appimage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.2] - 2025-12-29
+
+### Improvements
+- **Concurrency cleanup:** Replace custom goroutine tracker with standard WaitGroup patterns ([#61](https://github.com/AshBuk/speak-to-ai/pull/61))
+- **AppImage build refactoring:** Extract AppRun template, simplify build script (-62% lines) ([#62](https://github.com/AshBuk/speak-to-ai/pull/62))
+- **Documentation:** Update supported distributions list for glibc 2.35+
+
+---
 ## [1.4.1] - 2025-12-24
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -103,10 +103,14 @@ See changes: [CHANGELOG.md](CHANGELOG.md)
 
 ### System Requirements
 
-- **OS**: Linux (Ubuntu 20.04+, Fedora 35+, or similar)
+- **OS**: Linux with glibc 2.35+
+  - **Ubuntu-based:** Ubuntu 22.04+, Linux Mint 21+, Pop!_OS 22.04+, Elementary OS 7+, Zorin OS 17+
+  - **Debian-based:** Debian 12+
+  - **Fedora:** Fedora 36+
+  - **Rolling release:** Arch Linux, Manjaro, EndeavourOS, openSUSE Tumbleweed
 - **Desktop**: X11 or Wayland environment
 - **Audio**: Microphone/recording capability
-- **Storage**: 277.4MB (whisper small q5 model, dependencies, go-binary)
+- **Storage**: ~277MB (Whisper small-q5 model + dependencies)
 - **Memory**: ~300MB RAM during operation
 - **CPU**: AVX-capable processor (Intel/AMD 2011+)
 

--- a/bash-scripts/AppRun
+++ b/bash-scripts/AppRun
@@ -40,7 +40,7 @@ setup_first_launch() {
     else
         echo "Warning: Hotkeys may not work without additional setup."
         echo "For GNOME/KDE: Ensure D-Bus session is running"
-        echo "For other DEs: sudo usermod -a -G input \$USER"
+        echo "For other DEs: sudo usermod -a -G input $USER"
     fi
 }
 

--- a/bash-scripts/AppRun
+++ b/bash-scripts/AppRun
@@ -1,0 +1,91 @@
+#!/bin/bash
+# AppRun - Entry point for Speak-to-AI AppImage
+
+SELF=$(readlink -f "$0")
+HERE=${SELF%/*}
+export PATH="${HERE}/usr/bin:${PATH}"
+export LD_LIBRARY_PATH="${HERE}/usr/lib:${LD_LIBRARY_PATH}"
+
+# PulseAudio/PipeWire environment for audio recording
+export PULSE_SERVER="${PULSE_SERVER:-unix:${XDG_RUNTIME_DIR}/pulse/native}"
+export PULSE_RUNTIME_PATH="${PULSE_RUNTIME_PATH:-${XDG_RUNTIME_DIR}/pulse}"
+
+CONFIG_DIR="${HOME}/.config/speak-to-ai"
+mkdir -p "${CONFIG_DIR}"
+
+# Check if running in CLI mode
+is_cli_command() {
+    for arg in "$@"; do
+        case "$arg" in
+            start|stop|status|transcript) return 0 ;;
+        esac
+    done
+    return 1
+}
+
+# First launch setup (GUI mode only)
+setup_first_launch() {
+    if [ -f "${CONFIG_DIR}/config.yaml" ]; then
+        return
+    fi
+
+    echo "First launch detected: Setting up configuration..."
+    cp "${HERE}/config.yaml" "${CONFIG_DIR}/config.yaml"
+
+    # Check hotkey support
+    if command -v busctl >/dev/null 2>&1 && busctl --user status >/dev/null 2>&1; then
+        echo "D-Bus session available - hotkeys supported"
+    elif [ -r /dev/input/event0 ] 2>/dev/null; then
+        echo "Input devices accessible - hotkeys supported"
+    else
+        echo "Warning: Hotkeys may not work without additional setup."
+        echo "For GNOME/KDE: Ensure D-Bus session is running"
+        echo "For other DEs: sudo usermod -a -G input \$USER"
+    fi
+}
+
+# Desktop integration
+integrate_desktop() {
+    local desktop_file="${HOME}/.local/share/applications/speak-to-ai.desktop"
+    local icon_dir="${HOME}/.local/share/icons/hicolor/256x256/apps"
+
+    if [ -f "$desktop_file" ]; then
+        return
+    fi
+
+    # Skip if AppImageLauncher handles integration
+    if command -v appimaged >/dev/null 2>&1 || command -v appimageupdatetool >/dev/null 2>&1; then
+        return
+    fi
+
+    echo "Creating desktop menu integration..."
+    mkdir -p "$(dirname "$desktop_file")" "$icon_dir"
+
+    cat > "$desktop_file" << EOF
+[Desktop Entry]
+Name=Speak-to-AI
+Comment=Offline speech-to-text for AI assistants
+Exec="${SELF}" %U
+Icon=speak-to-ai
+Type=Application
+Categories=Utility;Audio;Accessibility;
+Terminal=false
+StartupNotify=true
+EOF
+    chmod +x "$desktop_file"
+    cp "${HERE}/speak-to-ai.png" "$icon_dir/" 2>/dev/null || true
+    command -v update-desktop-database >/dev/null 2>&1 && \
+        update-desktop-database "${HOME}/.local/share/applications" 2>/dev/null || true
+}
+
+# Main
+cd "${HERE}"
+
+if is_cli_command "$@"; then
+    [ ! -f "${CONFIG_DIR}/config.yaml" ] && cp "${HERE}/config.yaml" "${CONFIG_DIR}/config.yaml" 2>/dev/null || true
+    exec "${HERE}/usr/bin/speak-to-ai" "$@"
+else
+    setup_first_launch
+    integrate_desktop
+    exec "${HERE}/usr/bin/speak-to-ai" --config "${CONFIG_DIR}/config.yaml" "$@"
+fi

--- a/bash-scripts/build-appimage.sh
+++ b/bash-scripts/build-appimage.sh
@@ -71,13 +71,16 @@ build_appdir() {
     # Copy desktop file and icon (use existing files from repo)
     cp "io.github.ashbuk.speak-to-ai.desktop" "${APPDIR}/usr/share/applications/${APP_NAME}.desktop"
     cp "io.github.ashbuk.speak-to-ai.appdata.xml" "${APPDIR}/usr/share/metainfo/${APP_NAME}.appdata.xml"
+    # Copy icon with name matching Icon= field in .desktop file
+    cp "icons/io.github.ashbuk.speak-to-ai.png" "${APPDIR}/usr/share/icons/hicolor/256x256/apps/io.github.ashbuk.speak-to-ai.png"
+    # Also copy as short name for compatibility
     cp "icons/io.github.ashbuk.speak-to-ai.png" "${APPDIR}/usr/share/icons/hicolor/256x256/apps/${APP_NAME}.png"
 
     # Create symlinks for AppImage standard
     ln -sf "usr/share/applications/${APP_NAME}.desktop" "${APPDIR}/${APP_NAME}.desktop"
     ln -sf "usr/share/icons/hicolor/256x256/apps/${APP_NAME}.png" "${APPDIR}/${APP_NAME}.png"
     # Icon name must match Icon= field in .desktop file
-    ln -sf "usr/share/icons/hicolor/256x256/apps/${APP_NAME}.png" "${APPDIR}/io.github.ashbuk.speak-to-ai.png"
+    ln -sf "usr/share/icons/hicolor/256x256/apps/io.github.ashbuk.speak-to-ai.png" "${APPDIR}/io.github.ashbuk.speak-to-ai.png"
 }
 
 # Download AppImage tools
@@ -135,7 +138,7 @@ build_appimage() {
         $exec_args \
         $lib_args \
         --desktop-file "${APP_NAME}.AppDir/${APP_NAME}.desktop" \
-        --icon-file "${APP_NAME}.AppDir/${APP_NAME}.png" \
+        --icon-file "${APP_NAME}.AppDir/io.github.ashbuk.speak-to-ai.png" \
         --plugin gtk || echo "Warning: linuxdeploy had issues, continuing..."
 
     # Remove unnecessary docs (licenses available in source repos)

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -4,14 +4,14 @@
 
 | Metric | Value |
 | --- | --- |
-| **Go files (total)** | 131 |
+| **Go files (total)** | 129 |
 | **Production files** | 83 |
-| **Test files** | 43 |
-| **Mock files** | 6 |
-| **Production code** | 10,301 LOC |
-| **Test code** | 10,059 LOC |
-| **Mock code** | 1,194 LOC |
-| **Total codebase** | 21,554 LOC |
+| **Test files** | 42 |
+| **Mock files** | 5 |
+| **Production code** | 10,396 LOC |
+| **Test code** | 9,943 LOC |
+| **Mock code** | 1,107 LOC |
+| **Total codebase** | 21,446 LOC |
 
 ---
 
@@ -19,10 +19,10 @@
 
 | Metric | Value |
 | --- | --- |
-| **Test/Production ratio** | 0.97 (97%) |
-| **Average production file size** | ~124 lines |
-| **Average test file size** | ~233 lines |
-| **Average mock file size** | ~199 lines |
+| **Test/Production ratio** | 0.95 (95%) |
+| **Average production file size** | ~125 lines |
+| **Average test file size** | ~237 lines |
+| **Average mock file size** | ~221 lines |
 | **Test coverage** | High (includes unit and integration tests) |
 | **golangci-lint warnings** | 0 |
 | **Goroutine leaks** | 0 |
@@ -33,6 +33,6 @@
 | Metric | Value |
 | --- | --- |
 | **Development time** | ~8 months (Apr 2024 - Dec 2025) |
-| **Total commits** | 353 |
+| **Total commits** | 379 |
 
-**Last Updated:** 2025-12-21 (based on commit c0eecba)
+**Last Updated:** 2025-12-29 (based on commit f55a04d)

--- a/internal/assets/about.html
+++ b/internal/assets/about.html
@@ -197,9 +197,8 @@
 
     <div class="section">
         <div class="planned-features"></div>
-        <p><strong>Current version: 1.4.1</strong></p>
-        <p><strong>New:</strong> Optimized hotkey rebind, deterministic shutdown</p>
-        <p><strong>Next feature:</strong> VAD (Voice Activity Detection) with enable/disable option and sensitivity settings via menu</p>
+        <p><strong>Current version: 1.4.2</strong></p>
+        <p><strong>New:</strong> Concurrency cleanup, AppImage build refactoring</p>
     </div>
 
     <div class="section sponsor-buttons">

--- a/io.github.ashbuk.speak-to-ai.appdata.xml
+++ b/io.github.ashbuk.speak-to-ai.appdata.xml
@@ -47,26 +47,18 @@
     <binary>speak-to-ai</binary>
   </provides>
   <releases>
-    <release version="1.4.1" date="2025-12-25">
+    <release version="1.4.2" date="2025-12-29">
       <description>
-        <p>Performance and architecture improvements.</p>
+        <p>Code quality and build improvements.</p>
         <ul>
-          <li>Hotkey rebind optimization: latency reduced from ~1-2s to ~100ms</li>
-          <li>Deterministic shutdown with per-component goroutine ownership</li>
-          <li>Architecture cleanup: DIP compliance, removed Flatpak support</li>
+          <li>Concurrency cleanup: standard WaitGroup patterns replace custom tracker</li>
+          <li>AppImage build refactoring: simplified script, extracted AppRun template</li>
+          <li>Updated supported distributions documentation for glibc 2.35+</li>
         </ul>
       </description>
     </release>
-    <release version="1.4.0" date="2025-12-15">
-      <description>
-        <p>Full multi-language support with all 99 Whisper-supported languages.</p>
-        <ul>
-          <li>All Whisper languages: From Afrikaans to Yoruba, complete language coverage</li>
-          <li>Alphabetical grouping: Easy navigation with A-Z submenus</li>
-          <li>Quick reference: Current language displayed at menu top</li>
-        </ul>
-      </description>
-    </release>
+    <release version="1.4.1" date="2025-12-25"/>
+    <release version="1.4.0" date="2025-12-15"/>
     <release version="1.3.4" date="2025-12-07"/>
     <release version="1.3.3" date="2025-11-27"/>
     <release version="1.3.2" date="2025-11-13"/>


### PR DESCRIPTION
### Context
Analyzed AppImage against @probonopd's (AppImage maintainer) "known-good" criteria 

| Criterion | Status | Decision |
|-----------|--------|----------|
|  Works without installing packages | ✅ Pass | Bundles 200+ libraries, works on standard desktop Linux |
| Works on old distros (Debian oldstable) | ⚠️ Partial | Requires glibc 2.35+ (Ubuntu 22.04+). Rejected Ubuntu 20.04 — missing ydotool |
| Self-contained (kernel only) | ❌ Skip | Not practical for GTK3 apps — would add 500MB+ and break theme integration |
| No unnecessary content | ✅ Fixed | Removed `/usr/share/doc` |

### Build Flow

```
prepare_environment()
    ↓
download_model()
    ↓
build_appdir()          # Build Go binary, copy assets
    ↓
download_tools()        # linuxdeploy, appimagetool
    ↓
build_appimage()
    ├── linuxdeploy --plugin gtk  # Gather dependencies
    ├── rm -rf usr/share/doc      # Remove docs
    └── appimagetool              # Create final .AppImage
```

**Supported systems:**
- Ubuntu 22.04+ ✅
- Debian 12+ ✅
- Fedora 36+ ✅
- Linux Mint 21+, Pop!_OS 22.04+, Elementary OS 7+, Zorin OS 17+ ✅
- Arch Linux, Manjaro, EndeavourOS, openSUSE Tumbleweed ✅
