### PR TITLE
Packaging/arch pkgbuild

### DIFF
--- a/.github/workflows/lint-arch.yml
+++ b/.github/workflows/lint-arch.yml
@@ -1,0 +1,31 @@
+name: Lint Arch
+
+on:
+  push:
+    branches: [master, main]
+    paths:
+      - 'packaging/arch/**'
+  pull_request:
+    paths:
+      - 'packaging/arch/**'
+
+jobs:
+  namcap:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install namcap
+        run: pacman -Syu --noconfirm namcap pacman-contrib
+
+      - name: Lint PKGBUILD
+        run: namcap packaging/arch/PKGBUILD
+
+      - name: Validate .SRCINFO generation
+        run: |
+          cd packaging/arch
+          makepkg --printsrcinfo > .SRCINFO.test
+          echo "SRCINFO generated successfully"

--- a/.github/workflows/lint-arch.yml
+++ b/.github/workflows/lint-arch.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Validate .SRCINFO generation
         run: |
-          cd packaging/arch
-          makepkg --printsrcinfo > .SRCINFO.test
+          useradd -m builder
+          cp -r packaging/arch /home/builder/
+          chown -R builder:builder /home/builder/arch
+          su builder -c 'cd /home/builder/arch && makepkg --printsrcinfo > .SRCINFO'
           echo "SRCINFO generated successfully"

--- a/.github/workflows/lint-rpm.yml
+++ b/.github/workflows/lint-rpm.yml
@@ -1,4 +1,4 @@
-name: RPM Spec Lint
+name: Lint RPM
 
 on:
   push:

--- a/.github/workflows/release-appimage.yml
+++ b/.github/workflows/release-appimage.yml
@@ -1,4 +1,4 @@
-name: Build Releases
+name: Release AppImage
 
 on:
   push:
@@ -141,8 +141,8 @@ jobs:
       env:
         APP_VERSION: ${{ github.event.inputs.version || github.ref_name }}
       run: |
-        chmod +x bash-scripts/build-appimage.sh
-        bash -x bash-scripts/build-appimage.sh
+        chmod +x packaging/appimage/build-appimage.sh
+        bash -x packaging/appimage/build-appimage.sh
         
     - name: Verify AppImage
       run: |

--- a/.github/workflows/release-arch.yml
+++ b/.github/workflows/release-arch.yml
@@ -1,0 +1,86 @@
+name: Release Arch
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  aur-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Generate checksums
+        id: checksums
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          WHISPER_VERSION=$(grep -E '^_whisper_version=' packaging/arch/PKGBUILD | cut -d= -f2)
+
+          # Download and checksum main source
+          curl -sL -o source.tar.gz \
+            "https://github.com/AshBuk/speak-to-ai/archive/refs/tags/v${VERSION}.tar.gz"
+          MAIN_SHA256=$(sha256sum source.tar.gz | cut -d' ' -f1)
+
+          # Download and checksum whisper.cpp
+          curl -sL -o whisper.tar.gz \
+            "https://github.com/ggml-org/whisper.cpp/archive/refs/tags/v${WHISPER_VERSION}.tar.gz"
+          WHISPER_SHA256=$(sha256sum whisper.tar.gz | cut -d' ' -f1)
+
+          echo "MAIN_SHA256=${MAIN_SHA256}" >> $GITHUB_OUTPUT
+          echo "WHISPER_SHA256=${WHISPER_SHA256}" >> $GITHUB_OUTPUT
+
+          rm -f source.tar.gz whisper.tar.gz
+
+      - name: Update PKGBUILD version and checksums
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          MAIN_SHA256="${{ steps.checksums.outputs.MAIN_SHA256 }}"
+          WHISPER_SHA256="${{ steps.checksums.outputs.WHISPER_SHA256 }}"
+
+          cd packaging/arch
+
+          # Update version
+          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+
+          # Update checksums
+          sed -i "s/'SKIP'  # TODO: Update on release/'${MAIN_SHA256}'/" PKGBUILD
+          sed -i "s/'SKIP'  # whisper.cpp checksum/'${WHISPER_SHA256}'/" PKGBUILD
+
+      - name: Generate .SRCINFO
+        uses: docker://archlinux:latest
+        with:
+          entrypoint: /bin/bash
+          args: |
+            -c "
+              pacman -Syu --noconfirm pacman-contrib
+              cd packaging/arch
+              makepkg --printsrcinfo > .SRCINFO
+            "
+
+      - name: Lint PKGBUILD
+        uses: docker://archlinux:latest
+        with:
+          entrypoint: /bin/bash
+          args: |
+            -c "
+              pacman -Syu --noconfirm namcap
+              namcap packaging/arch/PKGBUILD
+            "
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v3.0.1
+        with:
+          pkgname: speak-to-ai
+          pkgbuild: packaging/arch/PKGBUILD
+          commit_username: ${{ secrets.AUR_USERNAME }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "Update to ${{ steps.version.outputs.VERSION }}"
+          force_push: false

--- a/.github/workflows/release-fedora.yml
+++ b/.github/workflows/release-fedora.yml
@@ -1,4 +1,4 @@
-name: COPR Build
+name: Release Fedora
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@
 </p>
   
 [![CI](https://github.com/AshBuk/speak-to-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/AshBuk/speak-to-ai/actions/workflows/ci.yml)
-[![Build Releases](https://github.com/AshBuk/speak-to-ai/actions/workflows/build-releases.yml/badge.svg)](https://github.com/AshBuk/speak-to-ai/actions/workflows/build-releases.yml)
-[![AppImage](https://img.shields.io/badge/AppImage-available-0a7cff?logo=appimage)](https://github.com/AshBuk/speak-to-ai/releases)
 [![Release](https://img.shields.io/github/v/release/AshBuk/speak-to-ai?sort=semver)](https://github.com/AshBuk/speak-to-ai/releases)
+[![AppImage](https://img.shields.io/badge/AppImage-available-0a7cff?logo=appimage)](https://github.com/AshBuk/speak-to-ai/releases)
+[![AUR](https://img.shields.io/aur/version/speak-to-ai?logo=archlinux)](https://aur.archlinux.org/packages/speak-to-ai)
+[![COPR](https://img.shields.io/badge/COPR-Fedora-51a2da?logo=fedora)](https://copr.fedorainfracloud.org/coprs/ashbuk/speak-to-ai/)
 
 </div>
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -37,13 +37,21 @@ make gosec                 # Run security scanner (SAST)
 make check-tools           # Verify required tools (local check)
 ```
 
-### 2. Bash Scripts - Orchestration & Dependencies
-Handle complex build logic and dependency management:
+### 2. Packaging Scripts
+Handle complex build logic and package creation:
 ```bash
-packaging/appimage/build-appimage.sh  # AppImage creation with linuxdeploy fallbacks
-packaging/fedora/speak-to-ai.spec     # RPM spec for Fedora/RHEL
-packaging/fedora/create-srpm.sh       # SRPM creation script
-bash-scripts/dev-env.sh               # CGO environment configuration
+packaging/
+├── appimage/
+│   ├── AppRun                    # AppImage entrypoint
+│   └── build-appimage.sh         # AppImage creation with linuxdeploy
+├── arch/
+│   └── PKGBUILD                  # Arch Linux AUR package
+└── fedora/
+    ├── speak-to-ai.spec          # RPM spec for Fedora/RHEL
+    ├── create-srpm.sh            # SRPM creation script
+    └── .rpmlintrc                # rpmlint configuration
+
+bash-scripts/dev-env.sh           # CGO environment configuration
 ```
 
 ### 3. Docker - Containers
@@ -62,7 +70,16 @@ make docker-clean-all  # Clean everything including images
 ```
 
 ### 4. CI/CD - Production
-GitHub Actions handle complex builds, releases, and distribution.
+GitHub Actions handle complex builds, releases, and distribution:
+```
+.github/workflows/
+├── ci.yml                  # Main CI (lint, test, build)
+├── lint-arch.yml           # PKGBUILD validation (namcap)
+├── lint-rpm.yml            # Spec validation (rpmlint)
+├── release-appimage.yml    # AppImage build & GitHub Release
+├── release-arch.yml        # AUR publish (on tag)
+└── release-fedora.yml      # COPR submit (on tag)
+```
 
 ### Test Types & Current Coverage 
 
@@ -114,4 +131,4 @@ hotkeys/
 
 See [`config.yaml`](../config.yaml) for the complete configuration file with all available options and detailed comments.
 
-*Last updated: 2025-10-31*
+*Last updated: 2026-01-06*

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,0 +1,135 @@
+# Maintainer: Asher Buk <AshBuk@users.noreply.github.com>
+# https://github.com/AshBuk/speak-to-ai
+
+pkgname=speak-to-ai
+pkgver=1.4.2
+pkgrel=1
+pkgdesc="Offline speech-to-text desktop application using Whisper"
+arch=('x86_64')
+url="https://github.com/AshBuk/speak-to-ai"
+license=('MIT')
+depends=(
+    'gtk3'
+    'libayatana-appindicator'
+    'dbus'
+    'alsa-utils'
+    'libnotify'
+    # Clipboard: X11 + Wayland
+    'xsel'
+    'wl-clipboard'
+    # Typing: X11 + Wayland
+    'xdotool'
+    'wtype'
+)
+optdepends=(
+    'ydotool: Alternative Wayland text input (better for GNOME)'
+    'ffmpeg: Alternative audio recording'
+)
+makedepends=(
+    'go>=1.21'
+    'gcc'
+    'cmake'
+    'git'
+)
+options=('!lto')
+# Whisper.cpp version (pinned for reproducibility)
+_whisper_version=1.8.2
+
+source=(
+    "${pkgname}-${pkgver}.tar.gz::https://github.com/AshBuk/speak-to-ai/archive/refs/tags/v${pkgver}.tar.gz"
+    "whisper-cpp-${_whisper_version}.tar.gz::https://github.com/ggml-org/whisper.cpp/archive/refs/tags/v${_whisper_version}.tar.gz"
+)
+sha256sums=(
+    'SKIP'  # TODO: Update on release
+    'SKIP'  # whisper.cpp checksum
+)
+
+prepare() {
+    cd "${pkgname}-${pkgver}"
+
+    # Setup whisper.cpp
+    mkdir -p build
+    ln -sf "${srcdir}/whisper.cpp-${_whisper_version}" build/whisper.cpp
+
+    # Vendor Go dependencies
+    export GOFLAGS="-mod=mod"
+    go mod download
+}
+
+build() {
+    cd "${pkgname}-${pkgver}"
+
+    # Build whisper.cpp libraries
+    pushd build/whisper.cpp
+    cmake -B build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_INSTALL_RPATH="/usr/lib/${pkgname}" \
+        -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+        -DGGML_NATIVE=OFF \
+        -DGGML_AVX=ON \
+        -DGGML_AVX2=ON \
+        -DGGML_FMA=ON \
+        -DGGML_F16C=ON
+    cmake --build build --parallel
+    popd
+
+    # Prepare lib directory for Go build
+    mkdir -p lib
+    cp build/whisper.cpp/build/src/libwhisper.so* lib/
+    cp build/whisper.cpp/include/whisper.h lib/
+    cp build/whisper.cpp/ggml/include/*.h lib/ 2>/dev/null || :
+    cp build/whisper.cpp/build/ggml/src/libggml*.so* lib/ 2>/dev/null || :
+
+    # Build Go binary with systray support
+    export CGO_ENABLED=1
+    export C_INCLUDE_PATH="${PWD}/lib"
+    export LIBRARY_PATH="${PWD}/lib"
+    export CGO_CFLAGS="-I${PWD}/lib"
+    export CGO_LDFLAGS="-L${PWD}/lib -lwhisper -lggml -lggml-cpu"
+    export LD_LIBRARY_PATH="${PWD}/lib"
+
+    go build -v \
+        -tags systray \
+        -ldflags "-s -w -X main.version=${pkgver} -linkmode=external -extldflags '-Wl,-rpath,/usr/lib/${pkgname}'" \
+        -o "${pkgname}" \
+        ./cmd/speak-to-ai
+}
+
+check() {
+    cd "${pkgname}-${pkgver}"
+
+    export LD_LIBRARY_PATH="${PWD}/lib"
+    ./"${pkgname}" -help 2>&1 | grep -q "speak-to-ai"
+}
+
+package() {
+    cd "${pkgname}-${pkgver}"
+
+    # Binary
+    install -Dm755 "${pkgname}" "${pkgdir}/usr/bin/${pkgname}"
+
+    # Bundled whisper libraries (private prefix to avoid conflicts)
+    install -dm755 "${pkgdir}/usr/lib/${pkgname}"
+    cp -a lib/libwhisper.so* "${pkgdir}/usr/lib/${pkgname}/"
+    cp -a lib/libggml*.so* "${pkgdir}/usr/lib/${pkgname}/" 2>/dev/null || :
+
+    # Desktop entry
+    install -Dm644 io.github.ashbuk.speak-to-ai.desktop \
+        "${pkgdir}/usr/share/applications/io.github.ashbuk.speak-to-ai.desktop"
+
+    # AppStream metainfo
+    install -Dm644 io.github.ashbuk.speak-to-ai.appdata.xml \
+        "${pkgdir}/usr/share/metainfo/io.github.ashbuk.speak-to-ai.appdata.xml"
+
+    # Icons
+    install -Dm644 icons/io.github.ashbuk.speak-to-ai.png \
+        "${pkgdir}/usr/share/icons/hicolor/128x128/apps/io.github.ashbuk.speak-to-ai.png"
+    install -Dm644 icons/io.github.ashbuk.speak-to-ai.svg \
+        "${pkgdir}/usr/share/icons/hicolor/scalable/apps/io.github.ashbuk.speak-to-ai.svg"
+
+    # License and documentation
+    install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+    install -Dm644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+    install -Dm644 CHANGELOG.md "${pkgdir}/usr/share/doc/${pkgname}/CHANGELOG.md"
+}

--- a/packaging/fedora/speak-to-ai.spec
+++ b/packaging/fedora/speak-to-ai.spec
@@ -60,7 +60,7 @@ Recommends:     wl-clipboard
 # Text input automation (X11: xdotool, Wayland: ydotool or wtype)
 Requires:       xdotool
 Recommends:     ydotool
-Suggests:       wtype
+Recommends:     wtype
 
 # Desktop notifications
 Requires:       libnotify


### PR DESCRIPTION
### Add Arch Linux Packaging (AUR)

Standard PKGBUILD for AUR with automated CI/CD — **Arch Packaging Standards** and `namcap` validation.

### Key Decisions

#### Bundled `whisper.cpp`
- Libraries installed into private prefix: `/usr/lib/speak-to-ai/`
- RPATH configured at build time — no `LD_LIBRARY_PATH` needed
- Avoids conflicts with system whisper.cpp packages

#### CI/CD Automation
- **`lint-arch.yml`**: namcap validation + .SRCINFO generation on push
- **`release-arch.yml`**: On tag push → update version/checksums → publish to AUR
- Version from git tag (single source of truth)

---

**Packaging Structure:**

packaging/
├── appimage/
│   ├── AppRun
│   └── build-appimage.sh
├── arch/
│   └── PKGBUILD
└── fedora/
    ├── .rpmlintrc
    ├── create-srpm.sh
    └── speak-to-ai.spec


