### PR TITLE
Feat/version cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.5.0] - 2026-01-06
+
+### Features
+- **Version flag:** Added `--version` / `-v` flag to display version information
+- **Package repositories:** Official packages now available for Arch Linux (AUR) and Fedora (COPR)
+
+### Installation
+- **Arch Linux (AUR):** `yay -S speak-to-ai`
+- **Fedora (COPR):** `sudo dnf copr enable ashbuk/speak-to-ai && sudo dnf install speak-to-ai`
+
+---
 ## [1.4.2] - 2025-12-29
 
 ### Improvements

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@
 
 # Variables
 GO_VERSION := 1.24.1
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+LDFLAGS := -s -w -X main.version=$(VERSION)
 BINARY_NAME := speak-to-ai
 BUILD_DIR := build
 LIB_DIR := lib
@@ -115,12 +117,12 @@ $(LIB_DIR)/whisper.h:
 # Build the main binary
 build: deps whisper-libs
 	@echo "=== Building $(BINARY_NAME) (Docker) ==="
-	$(DOCKER_RUN) bash -c 'go build -v -o $(BINARY_NAME) ./cmd/speak-to-ai && ls -lh $(BINARY_NAME)'
+	$(DOCKER_RUN) bash -c 'go build -v -ldflags "$(LDFLAGS)" -o $(BINARY_NAME) ./cmd/speak-to-ai && ls -lh $(BINARY_NAME)'
 
 # Build with systray support
 build-systray: deps whisper-libs
 	@echo "=== Building $(BINARY_NAME) with systray support (Docker) ==="
-	$(DOCKER_RUN) bash -c 'go build -tags systray -v -o $(BINARY_NAME) ./cmd/speak-to-ai && ls -lh $(BINARY_NAME)'
+	$(DOCKER_RUN) bash -c 'go build -tags systray -v -ldflags "$(LDFLAGS)" -o $(BINARY_NAME) ./cmd/speak-to-ai && ls -lh $(BINARY_NAME)'
 
 # ============================================================================
 # Packaging

--- a/README.md
+++ b/README.md
@@ -74,12 +74,23 @@ Download the latest AppImage from [Releases](https://github.com/AshBuk/speak-to-
 
 ```bash
 # Download the file, then:
- chmod +x speak-to-ai-*.AppImage
- # Ensure user is in input group for hotkeys to work:
- sudo usermod -a -G input $USER
- # then logout/login or reboot
- # Open via GUI or with terminal command:
- ./speak-to-ai-*.AppImage
+chmod +x speak-to-ai-*.AppImage
+# Ensure user is in input group for hotkeys to work:
+sudo usermod -a -G input $USER
+# then logout/login or reboot
+# Open via GUI or with terminal command:
+./speak-to-ai-*.AppImage
+```
+
+### Arch Linux [AUR](https://aur.archlinux.org/packages/speak-to-ai):
+```bash
+yay -S speak-to-ai
+```
+
+### Fedora [COPR](https://copr.fedorainfracloud.org/coprs/ashbuk/speak-to-ai/):
+```bash
+sudo dnf copr enable ashbuk/speak-to-ai
+sudo dnf install speak-to-ai
 ```
 
 ## Desktop Environment Compatibility

--- a/cmd/speak-to-ai/main.go
+++ b/cmd/speak-to-ai/main.go
@@ -17,6 +17,13 @@ import (
 func main() {
 	args := os.Args[1:]
 
+	// Handle --version / -v before anything else
+	for _, arg := range args {
+		if isVersionFlag(arg) {
+			printVersion()
+		}
+	}
+
 	if handled, exitCode := maybeRunCLI(args); handled {
 		os.Exit(exitCode)
 	}

--- a/cmd/speak-to-ai/usage.go
+++ b/cmd/speak-to-ai/usage.go
@@ -57,7 +57,7 @@ func reportUsageError(err error) {
 
 func printCombinedUsage(w io.Writer, daemonFS *flag.FlagSet) {
 	name := filepath.Base(os.Args[0])
-	if _, err := fmt.Fprintf(w, "Usage:\n  %s [daemon flags]\n  %s [CLI flags] <start|stop|status|transcript>\n\n", name, name); err != nil {
+	if _, err := fmt.Fprintf(w, "Usage:\n  %s [daemon flags]\n  %s [CLI flags] <start|stop|status|transcript>\n  %s --version\n\n", name, name, name); err != nil {
 		reportUsageError(err)
 		return
 	}

--- a/cmd/speak-to-ai/version.go
+++ b/cmd/speak-to-ai/version.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+// Version information - injected at build time via ldflags:
+//
+//	go build -ldflags "-X main.version=1.5.0"
+//
+// Defaults to "dev" for development builds.
+var version = "dev"
+
+// printVersion outputs version information and exits.
+// Format: speak-to-ai version X.Y.Z (go1.XX.X linux/amd64)
+func printVersion() {
+	fmt.Printf("speak-to-ai version %s (%s %s/%s)\n",
+		version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	os.Exit(0)
+}
+
+// isVersionFlag checks if the argument is a version flag.
+// Supports standard POSIX/GNU formats: -v (short) and --version (long).
+func isVersionFlag(arg string) bool {
+	return arg == "-v" || arg == "--version"
+}

--- a/internal/assets/about.html
+++ b/internal/assets/about.html
@@ -197,8 +197,8 @@
 
     <div class="section">
         <div class="planned-features"></div>
-        <p><strong>Current version: 1.4.2</strong></p>
-        <p><strong>New:</strong> Concurrency cleanup, AppImage build refactoring</p>
+        <p><strong>Current version: 1.5.0</strong></p>
+        <p><strong>New:</strong> Version flag (--version), native packages for <a href="https://aur.archlinux.org/packages/speak-to-ai" target="_blank">Arch (AUR)</a> and <a href="https://copr.fedorainfracloud.org/coprs/ashbuk/speak-to-ai/" target="_blank">Fedora (COPR)</a></p>
     </div>
 
     <div class="section sponsor-buttons">

--- a/io.github.ashbuk.speak-to-ai.appdata.xml
+++ b/io.github.ashbuk.speak-to-ai.appdata.xml
@@ -43,6 +43,15 @@
     <binary>speak-to-ai</binary>
   </provides>
   <releases>
+    <release version="1.5.0" date="2026-01-06">
+      <description>
+        <p>Version flag and native package support.</p>
+        <ul>
+          <li>Added --version / -v flag to display version information</li>
+          <li>Native packages: Arch Linux (AUR) and Fedora (COPR)</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.4.2" date="2025-12-29">
       <description>
         <p>Code quality and build improvements.</p>

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -2,7 +2,7 @@
 # https://github.com/AshBuk/speak-to-ai
 
 pkgname=speak-to-ai
-pkgver=1.4.2
+pkgver=1.5.0
 pkgrel=1
 pkgdesc="Offline speech-to-text desktop application using Whisper"
 arch=('x86_64')

--- a/packaging/fedora/speak-to-ai.spec
+++ b/packaging/fedora/speak-to-ai.spec
@@ -5,7 +5,7 @@
 # =============================================================================
 # Version definitions (single source of truth)
 # =============================================================================
-%global app_version     1.4.2
+%global app_version     1.5.0
 %global go_version      1.21
 %global whisper_version 1.8.2
 
@@ -228,6 +228,9 @@ fi
 %{_datadir}/icons/hicolor/scalable/apps/io.github.ashbuk.speak-to-ai.svg
 
 %changelog
+* Mon Jan 06 2026 Asher Buk <AshBuk@users.noreply.github.com> - 1.5.0-1
+- Add --version flag for version information display
+
 * Sun Jan 04 2026 Asher Buk <AshBuk@users.noreply.github.com> - 1.4.2-1
 - Initial RPM package for Fedora
 - Bundled whisper.cpp 1.8.2 for offline speech recognition


### PR DESCRIPTION
 - Display version, Go runtime and platform info.
Supports POSIX/GNU formats: -v and --version.
 - Add documentation for Arch (AUR) and Fedora (COPR) packages.
 - Bump version to 1.5.0.
