### PR TITLE
Feat/xdg model support

### DIFF
--- a/whisper/interfaces/model_manager.go
+++ b/whisper/interfaces/model_manager.go
@@ -21,8 +21,18 @@ type ModelManager interface {
 
 // Defines the contract for resolving the path to the small-q5_1 model
 type ModelPathResolver interface {
-	// Return the platform-specific path to the bundled model file
+	// Return the platform-specific path to the model file (searches multiple locations)
 	GetBundledModelPath() string
+	// Return the user data directory path for downloading the model
+	GetUserDataModelPath() string
+}
+
+// Defines the contract for downloading the whisper model
+type ModelDownloader interface {
+	// Download the model to the specified destination path
+	Download(destPath string) error
+	// Return the download URL
+	GetModelURL() string
 }
 
 // Represents a whisper.Model type without a direct CGO dependency

--- a/whisper/manager/model_manager.go
+++ b/whisper/manager/model_manager.go
@@ -14,37 +14,49 @@ import (
 )
 
 // Implements the logic for managing the fixed `small-q5_1` Whisper model.
-// It relies on a path resolver to find the bundled model file
+// It relies on a path resolver to find the model file and a downloader to fetch it
 type ModelManager struct {
 	config       *config.Config
-	pathResolver interfaces.ModelPathResolver
+	pathResolver *providers.ModelPathResolver
+	downloader   interfaces.ModelDownloader
 }
 
-// Create a new manager responsible for the bundled Whisper model
+// Create a new manager responsible for the Whisper model
 func NewModelManager(config *config.Config) *ModelManager {
 	pathResolver := providers.NewModelPathResolver(config)
+	downloader := providers.NewModelDownloader()
 
 	return &ModelManager{
 		config:       config,
 		pathResolver: pathResolver,
+		downloader:   downloader,
 	}
 }
 
-// Verify that the bundled `small-q5_1` model is present and valid
+// Verify that the `small-q5_1` model is present and valid.
+// If not found, attempts to download it to user data directory
 func (m *ModelManager) Initialize() error {
 	modelPath := m.pathResolver.GetBundledModelPath()
-	if _, err := os.Stat(modelPath); err != nil {
-		return fmt.Errorf("bundled small-q5_1 model not found at %s: %w", modelPath, err)
+
+	// Check if model exists
+	if _, err := os.Stat(modelPath); err == nil {
+		return m.ValidateModel(modelPath)
 	}
-	return m.ValidateModel(modelPath)
+
+	// Model not found - try to download to user data directory
+	downloadPath := m.pathResolver.GetUserDataModelPath()
+	if err := m.downloadModel(downloadPath); err != nil {
+		return fmt.Errorf("model not found and download failed: %w", err)
+	}
+
+	return m.ValidateModel(downloadPath)
 }
 
-// Return the path to the bundled `small-q5_1` model
-// Do not fall back to any other path; the bundled model must exist
+// Return the path to the `small-q5_1` model
 func (m *ModelManager) GetModelPath() (string, error) {
 	modelPath := m.pathResolver.GetBundledModelPath()
 	if !utils.IsValidFile(modelPath) {
-		return "", fmt.Errorf("bundled small-q5_1 model not found at %s", modelPath)
+		return "", fmt.Errorf("small-q5_1 model not found at %s", modelPath)
 	}
 	return modelPath, nil
 }
@@ -64,4 +76,9 @@ func (m *ModelManager) ValidateModel(modelPath string) error {
 		return fmt.Errorf("model file is too small (%d bytes), might be corrupted", size)
 	}
 	return nil
+}
+
+// downloadModel downloads the model to the specified path
+func (m *ModelManager) downloadModel(destPath string) error {
+	return m.downloader.Download(destPath)
 }

--- a/whisper/providers/model_downloader.go
+++ b/whisper/providers/model_downloader.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
+package providers
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+const (
+	// ModelDownloadURL is the URL to download the whisper small-q5_1 model
+	ModelDownloadURL = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small-q5_1.bin"
+	// MinModelSize is the minimum expected model size (180 MB)
+	MinModelSize = 180 * 1024 * 1024
+)
+
+// ModelDownloader handles downloading the whisper model from Hugging Face
+type ModelDownloader struct {
+	url string
+}
+
+// NewModelDownloader creates a new downloader with the default model URL
+func NewModelDownloader() *ModelDownloader {
+	return &ModelDownloader{url: ModelDownloadURL}
+}
+
+// Download downloads the model to the specified path
+// Creates parent directories if they don't exist
+func (d *ModelDownloader) Download(destPath string) error {
+	// Create parent directories
+	dir := filepath.Dir(destPath)
+	// #nosec G301 -- Model directory needs to be readable by the application
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create model directory %s: %w", dir, err)
+	}
+
+	// Create temporary file for atomic download
+	tmpPath := destPath + ".tmp"
+
+	// Download to temporary file
+	if err := d.downloadToFile(tmpPath); err != nil {
+		_ = os.Remove(tmpPath) // Clean up on error
+		return err
+	}
+
+	// Verify download size
+	info, err := os.Stat(tmpPath)
+	if err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("failed to stat downloaded file: %w", err)
+	}
+	if info.Size() < MinModelSize {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("downloaded model is too small (%d bytes), expected at least %d bytes", info.Size(), MinModelSize)
+	}
+
+	// Atomic rename
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("failed to move model to final location: %w", err)
+	}
+	return nil
+}
+
+// downloadToFile downloads the model URL to the specified file
+func (d *ModelDownloader) downloadToFile(path string) error {
+	// Create HTTP request
+	resp, err := http.Get(d.url) // #nosec G107 -- URL is a constant, not user input
+	if err != nil {
+		return fmt.Errorf("failed to download model: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download model: HTTP %d", resp.StatusCode)
+	}
+
+	// Create output file
+	// #nosec G304 -- path is constructed internally, not from user input
+	out, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create model file: %w", err)
+	}
+	defer func() { _ = out.Close() }()
+
+	// Copy response body to file
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to write model file: %w", err)
+	}
+	return nil
+}
+
+// GetModelURL returns the download URL
+func (d *ModelDownloader) GetModelURL() string {
+	return d.url
+}

--- a/whisper/providers/model_downloader_test.go
+++ b/whisper/providers/model_downloader_test.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
+package providers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestModelDownloader_Download_Success(t *testing.T) {
+	// Create mock server with fake model data
+	modelData := strings.Repeat("x", MinModelSize+1000) // Slightly larger than minimum
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(modelData))
+	}))
+	defer server.Close()
+
+	// Create downloader with mock URL
+	downloader := &ModelDownloader{url: server.URL}
+	// Download to temp directory
+	destPath := filepath.Join(t.TempDir(), "models", "test_model.bin")
+	err := downloader.Download(destPath)
+	if err != nil {
+		t.Fatalf("Download failed: %v", err)
+	}
+	// Verify file exists and has correct size
+	info, err := os.Stat(destPath)
+	if err != nil {
+		t.Fatalf("Downloaded file not found: %v", err)
+	}
+	if info.Size() != int64(len(modelData)) {
+		t.Errorf("File size mismatch: expected %d, got %d", len(modelData), info.Size())
+	}
+}
+
+func TestModelDownloader_Download_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	downloader := &ModelDownloader{url: server.URL}
+	destPath := filepath.Join(t.TempDir(), "test_model.bin")
+	err := downloader.Download(destPath)
+	if err == nil {
+		t.Fatal("Expected error for HTTP 404, got nil")
+	}
+	if !strings.Contains(err.Error(), "HTTP 404") {
+		t.Errorf("Error should mention HTTP status: %v", err)
+	}
+}
+
+func TestModelDownloader_Download_TooSmall(t *testing.T) {
+	// Return data smaller than minimum
+	smallData := "too small"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(smallData))
+	}))
+	defer server.Close()
+
+	downloader := &ModelDownloader{url: server.URL}
+	destPath := filepath.Join(t.TempDir(), "test_model.bin")
+	err := downloader.Download(destPath)
+	if err == nil {
+		t.Fatal("Expected error for too small file, got nil")
+	}
+	if !strings.Contains(err.Error(), "too small") {
+		t.Errorf("Error should mention size: %v", err)
+	}
+	// Verify temp file was cleaned up
+	tmpPath := destPath + ".tmp"
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Error("Temporary file should be cleaned up on error")
+	}
+}
+
+func TestModelDownloader_Download_CreatesDirectories(t *testing.T) {
+	modelData := strings.Repeat("x", MinModelSize+1000)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(modelData))
+	}))
+	defer server.Close()
+
+	downloader := &ModelDownloader{url: server.URL}
+	// Use deeply nested path that doesn't exist
+	destPath := filepath.Join(t.TempDir(), "a", "b", "c", "model.bin")
+	err := downloader.Download(destPath)
+	if err != nil {
+		t.Fatalf("Download failed: %v", err)
+	}
+	// Verify directories were created
+	if _, err := os.Stat(filepath.Dir(destPath)); os.IsNotExist(err) {
+		t.Error("Parent directories should be created")
+	}
+}
+
+func TestModelDownloader_Download_AtomicWrite(t *testing.T) {
+	modelData := strings.Repeat("x", MinModelSize+1000)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(modelData))
+	}))
+	defer server.Close()
+
+	downloader := &ModelDownloader{url: server.URL}
+	destPath := filepath.Join(t.TempDir(), "model.bin")
+	err := downloader.Download(destPath)
+	if err != nil {
+		t.Fatalf("Download failed: %v", err)
+	}
+	// Verify no .tmp file remains
+	tmpPath := destPath + ".tmp"
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Error("Temporary file should not remain after successful download")
+	}
+}
+
+func TestNewModelDownloader(t *testing.T) {
+	downloader := NewModelDownloader()
+
+	if downloader.url != ModelDownloadURL {
+		t.Errorf("Expected URL %q, got %q", ModelDownloadURL, downloader.url)
+	}
+}
+
+func TestModelDownloader_GetModelURL(t *testing.T) {
+	downloader := NewModelDownloader()
+
+	if downloader.GetModelURL() != ModelDownloadURL {
+		t.Errorf("GetModelURL() = %q, want %q", downloader.GetModelURL(), ModelDownloadURL)
+	}
+}
+
+func TestModelDownloader_Download_NetworkError(t *testing.T) {
+	// Use invalid URL to simulate network error
+	downloader := &ModelDownloader{url: "http://invalid.invalid.invalid:99999"}
+	destPath := filepath.Join(t.TempDir(), "model.bin")
+
+	err := downloader.Download(destPath)
+	if err == nil {
+		t.Fatal("Expected error for network failure, got nil")
+	}
+}

--- a/whisper/providers/model_path_resolver_test.go
+++ b/whisper/providers/model_path_resolver_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
+package providers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/AshBuk/speak-to-ai/config"
+)
+
+func TestGetBundledModelPath_AppImage(t *testing.T) {
+	// Create temp directory structure for AppImage
+	appDir := t.TempDir()
+	modelDir := filepath.Join(appDir, "sources", "language-models")
+	if err := os.MkdirAll(modelDir, 0o755); err != nil {
+		t.Fatalf("failed to create model dir: %v", err)
+	}
+	modelPath := filepath.Join(modelDir, ModelFileName)
+	if err := os.WriteFile(modelPath, []byte("test"), 0o644); err != nil {
+		t.Fatalf("failed to create model file: %v", err)
+	}
+
+	// Set APPDIR environment variable
+	t.Setenv("APPDIR", appDir)
+
+	resolver := NewModelPathResolver(&config.Config{})
+	result := resolver.GetBundledModelPath()
+	expected := filepath.Join(appDir, "sources/language-models", ModelFileName)
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestGetBundledModelPath_UserData(t *testing.T) {
+	// Clear APPDIR to skip AppImage check
+	t.Setenv("APPDIR", "")
+
+	// Create temp XDG_DATA_HOME
+	dataHome := t.TempDir()
+	modelDir := filepath.Join(dataHome, AppDataDirName, ModelsDirName)
+	if err := os.MkdirAll(modelDir, 0o755); err != nil {
+		t.Fatalf("failed to create model dir: %v", err)
+	}
+	modelPath := filepath.Join(modelDir, ModelFileName)
+	if err := os.WriteFile(modelPath, []byte("test"), 0o644); err != nil {
+		t.Fatalf("failed to create model file: %v", err)
+	}
+
+	t.Setenv("XDG_DATA_HOME", dataHome)
+
+	resolver := NewModelPathResolver(&config.Config{})
+	result := resolver.GetBundledModelPath()
+	if result != modelPath {
+		t.Errorf("expected %q, got %q", modelPath, result)
+	}
+}
+
+func TestGetBundledModelPath_DevPath(t *testing.T) {
+	// Clear environment variables
+	t.Setenv("APPDIR", "")
+	t.Setenv("XDG_DATA_HOME", "/nonexistent")
+
+	// Create dev path in temp directory and change to it
+	tempDir := t.TempDir()
+	devModelDir := filepath.Join(tempDir, "sources", "language-models")
+	if err := os.MkdirAll(devModelDir, 0o755); err != nil {
+		t.Fatalf("failed to create dev model dir: %v", err)
+	}
+	devModelPath := filepath.Join(devModelDir, ModelFileName)
+	if err := os.WriteFile(devModelPath, []byte("test"), 0o644); err != nil {
+		t.Fatalf("failed to create model file: %v", err)
+	}
+
+	// Change to temp directory so relative path works
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to change directory: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+
+	resolver := NewModelPathResolver(&config.Config{})
+	result := resolver.GetBundledModelPath()
+	expected := filepath.Join("sources/language-models", ModelFileName)
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestGetBundledModelPath_FallbackToUserData(t *testing.T) {
+	// Clear environment - no model exists anywhere
+	t.Setenv("APPDIR", "")
+	dataHome := t.TempDir() // Empty directory
+	t.Setenv("XDG_DATA_HOME", dataHome)
+
+	resolver := NewModelPathResolver(&config.Config{})
+	result := resolver.GetBundledModelPath()
+	// Should return user data path as default download location
+	expected := filepath.Join(dataHome, AppDataDirName, ModelsDirName, ModelFileName)
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestGetUserDataModelPath(t *testing.T) {
+	dataHome := "/custom/data/home"
+	t.Setenv("XDG_DATA_HOME", dataHome)
+
+	resolver := NewModelPathResolver(&config.Config{})
+	result := resolver.GetUserDataModelPath()
+	expected := filepath.Join(dataHome, AppDataDirName, ModelsDirName, ModelFileName)
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestGetUserDataModelPath_DefaultHome(t *testing.T) {
+	// Clear XDG_DATA_HOME to use default
+	t.Setenv("XDG_DATA_HOME", "")
+
+	resolver := NewModelPathResolver(&config.Config{})
+	result := resolver.GetUserDataModelPath()
+	home, _ := os.UserHomeDir()
+	expected := filepath.Join(home, ".local", "share", AppDataDirName, ModelsDirName, ModelFileName)
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestFileExists(t *testing.T) {
+	// Create temp file
+	tempFile, err := os.CreateTemp("", "test_model")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tempFile.Name())
+	tempFile.Close()
+
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"existing file", tempFile.Name(), true},
+		{"non-existing file", "/nonexistent/path/file.bin", false},
+		{"directory", os.TempDir(), false},
+		{"empty path", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := fileExists(tt.path)
+			if result != tt.expected {
+				t.Errorf("fileExists(%q) = %v, want %v", tt.path, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestModelPathResolver_Priority(t *testing.T) {
+	// Test that AppImage path takes priority over user data path
+	appDir := t.TempDir()
+	dataHome := t.TempDir()
+
+	// Create model in both locations
+	appImageModelDir := filepath.Join(appDir, "sources", "language-models")
+	userModelDir := filepath.Join(dataHome, AppDataDirName, ModelsDirName)
+
+	for _, dir := range []string{appImageModelDir, userModelDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("failed to create dir %s: %v", dir, err)
+		}
+		modelPath := filepath.Join(dir, ModelFileName)
+		if err := os.WriteFile(modelPath, []byte("test"), 0o644); err != nil {
+			t.Fatalf("failed to create model file: %v", err)
+		}
+	}
+
+	t.Setenv("APPDIR", appDir)
+	t.Setenv("XDG_DATA_HOME", dataHome)
+
+	resolver := NewModelPathResolver(&config.Config{})
+	result := resolver.GetBundledModelPath()
+	// AppImage should take priority
+	expected := filepath.Join(appDir, "sources/language-models", ModelFileName)
+	if result != expected {
+		t.Errorf("AppImage path should take priority: expected %q, got %q", expected, result)
+	}
+}


### PR DESCRIPTION
Support runtime model download for Fedora/Arch builds.

whisper small-q5_1 model is downloaded to ~/.local/share/speak-to-ai/models/ on first run
if not found in bundled locations.