### PR TITLE
Release/v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.5.2] - 2026-01-07
+
+### Changes
+- **Hotkey provider:** evdev is now the default (was D-Bus GlobalShortcuts). More reliable when user is in `input` group. D-Bus available as fallback.
+
+### Fixes
+- **AppImage config (for 1.5.X versions):** Use XDG config, fixing key rebinding and settings persistence.
+
+---
 ## [1.5.1] - 2026-01-06
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -85,12 +85,16 @@ sudo usermod -a -G input $USER
 ### Arch Linux [AUR](https://aur.archlinux.org/packages/speak-to-ai):
 ```bash
 yay -S speak-to-ai
+# Ensure user is in input group:
+sudo usermod -a -G input $USER
 ```
 
 ### Fedora [COPR](https://copr.fedorainfracloud.org/coprs/ashbuk/speak-to-ai/):
 ```bash
 sudo dnf copr enable ashbuk/speak-to-ai
 sudo dnf install speak-to-ai
+# Ensure user is in input group:
+sudo usermod -a -G input $USER
 ```
 
 ## Desktop Environment Compatibility

--- a/internal/assets/about.html
+++ b/internal/assets/about.html
@@ -197,8 +197,8 @@
 
     <div class="section">
         <div class="planned-features"></div>
-        <p><strong>Current version: 1.5.1</strong></p>
-        <p><strong>New:</strong> Version flag (--version), native packages for <a href="https://aur.archlinux.org/packages/speak-to-ai" target="_blank">Arch (AUR)</a> and <a href="https://copr.fedorainfracloud.org/coprs/ashbuk/speak-to-ai/" target="_blank">Fedora (COPR)</a></p>
+        <p><strong>Current version: 1.5.2</strong></p>
+        <p><strong>New:</strong> evdev hotkey provider by default, unified XDG config path. Native packages for <a href="https://aur.archlinux.org/packages/speak-to-ai" target="_blank">Arch (AUR)</a> and <a href="https://copr.fedorainfracloud.org/coprs/ashbuk/speak-to-ai/" target="_blank">Fedora (COPR)</a></p>
     </div>
 
     <div class="section sponsor-buttons">

--- a/io.github.ashbuk.speak-to-ai.appdata.xml
+++ b/io.github.ashbuk.speak-to-ai.appdata.xml
@@ -43,23 +43,17 @@
     <binary>speak-to-ai</binary>
   </provides>
   <releases>
-    <release version="1.5.1" date="2026-01-06">
+    <release version="1.5.2" date="2026-01-07">
       <description>
-        <p>Auto-download model for package builds.</p>
+        <p>Hotkey and config improvements.</p>
         <ul>
-          <li>Whisper model downloaded to ~/.local/share/speak-to-ai/models/ on first run</li>
+          <li>Hotkey provider: evdev is now the default (more reliable)</li>
+          <li>Config path: use XDG path for all installations</li>
         </ul>
       </description>
     </release>
-    <release version="1.5.0" date="2026-01-06">
-      <description>
-        <p>Version flag and native package support.</p>
-        <ul>
-          <li>Added --version / -v flag to display version information</li>
-          <li>Native packages: Arch Linux (AUR) and Fedora (COPR)</li>
-        </ul>
-      </description>
-    </release>
+    <release version="1.5.1" date="2026-01-06"/>
+    <release version="1.5.0" date="2026-01-06"/>
     <release version="1.4.2" date="2025-12-29"/>
     <release version="1.4.1" date="2025-12-25"/>
     <release version="1.4.0" date="2025-12-15"/>

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -2,7 +2,7 @@
 # https://github.com/AshBuk/speak-to-ai
 
 pkgname=speak-to-ai
-pkgver=1.5.1
+pkgver=1.5.2
 pkgrel=1
 pkgdesc="Offline speech-to-text desktop application using Whisper"
 arch=('x86_64')

--- a/packaging/fedora/speak-to-ai.spec
+++ b/packaging/fedora/speak-to-ai.spec
@@ -5,7 +5,7 @@
 # =============================================================================
 # Version definitions (single source of truth)
 # =============================================================================
-%global app_version     1.5.1
+%global app_version     1.5.2
 %global go_version      1.21
 %global whisper_version 1.8.2
 
@@ -228,6 +228,10 @@ fi
 %{_datadir}/icons/hicolor/scalable/apps/io.github.ashbuk.speak-to-ai.svg
 
 %changelog
+* Tue Jan 07 2026 Asher Buk <AshBuk@users.noreply.github.com> - 1.5.2-1
+- Hotkey provider: evdev is now the default (more reliable)
+- Config path: use XDG path for all installations
+
 * Mon Jan 06 2026 Asher Buk <AshBuk@users.noreply.github.com> - 1.5.1-1
 - Auto-download whisper model to ~/.local/share/speak-to-ai/models/ on first run
 


### PR DESCRIPTION
**patch for version1.5.x**
- **AppImage config:** Use XDG config path instead of read-only bundled config, fixing key rebinding and settings persistence in 1.5.x. versions

