### PR TITLE
Refactor/tray decouple callbacks

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,6 @@ general:
 hotkeys:
   start_recording: "alt+r"            # Start/stop recording
   stop_recording: "alt+r"             # Same combination for start/stop
-  # toggle_vad: "altgr+shift+v"          # Toggle VAD on/off
   show_config: "alt+c"                # Open configuration file
   reset_to_defaults: "alt+d"          # Reset all settings to defaults
 
@@ -22,10 +21,6 @@ audio:
   format: "s16le"               # Note: audio is always recorded in mono (1 channel)
   recording_method: "arecord"   # Options: "arecord", "ffmpeg"
   temp_file_cleanup_time: 30    # Auto-delete temporary audio files older than X minutes (default: 30)
-  # TODO: Next feature - VAD implementation
-  # enable_vad: false           # Enable Voice Activity Detection
-  # vad_sensitivity: "medium"   # VAD sensitivity: "low", "medium", "high"
-  # auto_start_stop: false      # Auto start/stop recording based on VAD
 
 # Text output settings
 output:

--- a/config/loaders/yaml_loader.go
+++ b/config/loaders/yaml_loader.go
@@ -76,12 +76,6 @@ func SetDefaultConfig(config *models.Config) {
 	config.Audio.MaxRecordingTime = 300   // 5 minutes max by default
 	config.Audio.TempFileCleanupTime = 30 // 30 minutes cleanup timeout by default
 
-	// TODO: Next feature - VAD implementation
-	// config.Hotkeys.ToggleVAD = "alt+v"       // Start/stop VAD
-	// config.Audio.EnableVAD = false         // VAD disabled by default for compatibility
-	// config.Audio.VADSensitivity = "medium" // Balanced VAD sensitivity
-	// config.Audio.AutoStartStop = false     // Manual control by default
-
 	// Output settings
 	config.Output.DefaultMode = models.OutputModeActiveWindow
 	config.Output.ClipboardTool = "auto" // auto-detect

--- a/config/models/config.go
+++ b/config/models/config.go
@@ -27,8 +27,6 @@ type Config struct {
 		StopRecording   string `yaml:"stop_recording"`
 		ShowConfig      string `yaml:"show_config"`
 		ResetToDefaults string `yaml:"reset_to_defaults"`
-		// TODO: VAD hotkey to be implemented
-		// ToggleVAD       string `yaml:"toggle_vad"`
 	} `yaml:"hotkeys"`
 
 	Audio struct {
@@ -39,10 +37,6 @@ type Config struct {
 		ExpectedDuration    int    `yaml:"expected_duration"`      // Expected recording duration in seconds (0 for indefinite)
 		MaxRecordingTime    int    `yaml:"max_recording_time"`     // Maximum recording time in seconds to prevent runaway recordings
 		TempFileCleanupTime int    `yaml:"temp_file_cleanup_time"` // Cleanup timeout for temp files in minutes (default: 30)
-		// TODO: Next feature - VAD implementation
-		// EnableVAD         bool   `yaml:"enable_vad"`          // Enable Voice Activity Detection
-		// VADSensitivity    string `yaml:"vad_sensitivity"`     // VAD sensitivity: 'low', 'medium', 'high'
-		// AutoStartStop     bool   `yaml:"auto_start_stop"`     // Automatically start/stop recording based on voice activity
 	} `yaml:"audio"`
 
 	Output struct {

--- a/config/validators/standard_validator_test.go
+++ b/config/validators/standard_validator_test.go
@@ -22,10 +22,6 @@ func setDefaultConfigForTest(config *models.Config) {
 	config.Audio.RecordingMethod = "arecord"
 	config.Audio.ExpectedDuration = 0
 	config.Audio.MaxRecordingTime = 300
-	// TODO: Next feature - VAD implementation
-	// config.Audio.EnableVAD = false
-	// config.Audio.VADSensitivity = "medium"
-	// config.Audio.AutoStartStop = false
 
 	config.Output.DefaultMode = models.OutputModeActiveWindow
 	config.Output.ClipboardTool = "auto"

--- a/hotkeys/adapters/adapter.go
+++ b/hotkeys/adapters/adapter.go
@@ -13,10 +13,8 @@ type HotkeyConfig interface {
 
 // Adapts a generic configuration to the HotkeyConfig interface
 type ConfigAdapter struct {
-	startRecording string
-	provider       string
-	// Hotkey for toggling VAD
-	// toggleVAD       string
+	startRecording  string
+	provider        string
 	showConfig      string
 	resetToDefaults string
 }
@@ -30,8 +28,7 @@ func NewConfigAdapter(startRecording string, provider string) *ConfigAdapter {
 }
 
 // Set optional action hotkeys using a builder pattern
-func (c *ConfigAdapter) WithAdditionalHotkeys(toggleVAD, showConfig, resetToDefaults string) *ConfigAdapter {
-	// c.toggleVAD = toggleVAD
+func (c *ConfigAdapter) WithAdditionalHotkeys(showConfig, resetToDefaults string) *ConfigAdapter {
 	c.showConfig = showConfig
 	c.resetToDefaults = resetToDefaults
 	return c
@@ -53,8 +50,6 @@ func (c *ConfigAdapter) GetProvider() string {
 // Return the hotkey string for a given action name
 func (c *ConfigAdapter) GetActionHotkey(action string) string {
 	switch action {
-	// case "toggle_vad":
-	// 	return c.toggleVAD
 	case "show_config":
 		return c.showConfig
 	case "reset_to_defaults":

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -133,10 +133,8 @@ func (a *App) setupHotkeyCallbacks() error {
 	if err := a.Services.Hotkeys.SetupHotkeyCallbacks(
 		a.handleStartRecording,             // handlers.go: Start audio recording
 		a.handleStopRecordingAndTranscribe, // handlers.go: Stop recording and transcribe
-		// TODO: Next feature - VAD implementation
-		// a.handleToggleVAD,                 // handlers.go: Toggle Voice Activity Detection
-		a.handleShowConfig,      // handlers.go: Display configuration
-		a.handleResetToDefaults, // handlers.go: Reset settings to defaults
+		a.handleShowConfig,                 // handlers.go: Display configuration
+		a.handleResetToDefaults,            // handlers.go: Reset settings to defaults
 	); err != nil {
 		return fmt.Errorf("failed to set up hotkey callbacks: %w", err)
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -195,11 +195,6 @@ func TestApp_HandlerMethods_NilServices(t *testing.T) {
 		t.Error("handleStopRecordingAndTranscribe should fail with nil services")
 	}
 
-	// TODO: Next feature - VAD implementation
-	// if err := app.handleToggleVAD(); err == nil {
-	//	t.Error("handleToggleVAD should fail with nil services")
-	// }
-
 	if err := app.handleShowConfig(); err == nil {
 		t.Error("handleShowConfig should fail with nil services")
 	}
@@ -220,11 +215,6 @@ func TestApp_HandlerMethods_NilSpecificServices(t *testing.T) {
 	if err := app.handleStopRecordingAndTranscribe(); err == nil {
 		t.Error("handleStopRecordingAndTranscribe should fail with nil audio service")
 	}
-
-	// TODO: Next feature - VAD implementation
-	// if err := app.handleToggleVAD(); err == nil {
-	//	t.Error("handleToggleVAD should fail with nil config service")
-	// }
 
 	if err := app.handleShowConfig(); err == nil {
 		t.Error("handleShowConfig should fail with nil UI service")

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -41,15 +41,6 @@ func (a *App) handleStopRecordingAndTranscribe() error {
 	return a.Services.Audio.HandleStopRecording()
 }
 
-// handleToggleVAD handles VAD toggle hotkey
-// TODO: Next feature - VAD implementation
-// func (a *App) handleToggleVAD() error {
-//	if a.Services == nil || a.Services.Config == nil {
-//		return fmt.Errorf("config service not available")
-//	}
-//	return a.Services.Config.ToggleVAD()
-// }
-
 // handleShowConfig Adapter - delegates show config hotkey to UIService
 func (a *App) handleShowConfig() error {
 	if a.Services == nil || a.Services.UI == nil {
@@ -72,7 +63,7 @@ func (a *App) handleResetToDefaults() error {
 		cfgProvider := func() adapters.HotkeyConfig {
 			if cfg := a.Services.Config.GetConfig(); cfg != nil {
 				return adapters.NewConfigAdapter(cfg.Hotkeys.StartRecording, cfg.Hotkeys.Provider).
-					WithAdditionalHotkeys("", cfg.Hotkeys.ShowConfig, cfg.Hotkeys.ResetToDefaults)
+					WithAdditionalHotkeys(cfg.Hotkeys.ShowConfig, cfg.Hotkeys.ResetToDefaults)
 			}
 			return adapters.NewConfigAdapter("", "auto")
 		}

--- a/internal/services/audio_service.go
+++ b/internal/services/audio_service.go
@@ -101,12 +101,6 @@ func (as *AudioService) HandleStartRecording() error {
 		as.setUIError(constants.MsgRecorderUnavailable)
 		return fmt.Errorf("audio recorder not available: %w", err)
 	}
-	// Choose recording mode
-	// TODO: Next feature - VAD implementation
-	// if as.config.Audio.EnableVAD && as.config.Audio.AutoStartStop {
-	//	return as.HandleStartVADRecording()
-	// }
-
 	// Standard recording
 	return as.startStandardRecording()
 }
@@ -188,16 +182,6 @@ func (as *AudioService) GetLastTranscript() string {
 	defer as.mu.RUnlock()
 	return as.lastTranscript
 }
-
-// TODO: Next feature - VAD implementation
-// HandleStartVADRecording starts VAD-based recording
-// func (as *AudioService) HandleStartVADRecording() error {
-//	as.logger.Info("Starting VAD recording...")
-//
-//	// VAD implementation would go here
-//	// For now, fallback to standard recording
-//	return as.startStandardRecording()
-// }
 
 // ensureModelAvailable ensures whisper model is ready
 func (as *AudioService) ensureModelAvailable() error {

--- a/internal/services/config_service.go
+++ b/internal/services/config_service.go
@@ -81,29 +81,6 @@ func (cs *ConfigService) GetConfig() *config.Config {
 	return cs.config
 }
 
-// TODO: Next feature - VAD implementation
-// UpdateVADSensitivity implements ConfigServiceInterface
-// func (cs *ConfigService) UpdateVADSensitivity(sensitivity string) error {
-//	cs.logger.Info("Updating VAD sensitivity to: %s", sensitivity)
-//
-//	s := strings.ToLower(sensitivity)
-//	switch s {
-//	case "low", "medium", "high":
-//	default:
-//		return fmt.Errorf("invalid VAD sensitivity: %s", sensitivity)
-//	}
-//	if cs.config.Audio.VADSensitivity == s {
-//		return nil
-//	}
-//	old := cs.config.Audio.VADSensitivity
-//	cs.config.Audio.VADSensitivity = s
-//	if err := cs.SaveConfig(); err != nil {
-//		cs.config.Audio.VADSensitivity = old
-//		return fmt.Errorf("failed to save config: %w", err)
-//	}
-//	return nil
-// }
-
 // Change whisper language setting with rollback on save failure
 func (cs *ConfigService) UpdateLanguage(language string) error {
 	cs.logger.Info("Updating language to: %s", language)
@@ -142,14 +119,6 @@ func (cs *ConfigService) ToggleWorkflowNotifications() error {
 	cs.config.Notifications.EnableWorkflowNotifications = !cs.config.Notifications.EnableWorkflowNotifications
 	return cs.SaveConfig()
 }
-
-// TODO: Next feature - VAD implementation
-// ToggleVAD implements ConfigServiceInterface
-// func (cs *ConfigService) ToggleVAD() error {
-//	cs.logger.Info("Toggling VAD mode")
-//	cs.config.Audio.EnableVAD = !cs.config.Audio.EnableVAD
-//	return cs.SaveConfig()
-// }
 
 // Switch audio backend (arecord/ffmpeg) with validation and persistence
 func (cs *ConfigService) UpdateRecordingMethod(method string) error {

--- a/internal/services/config_service_test.go
+++ b/internal/services/config_service_test.go
@@ -17,9 +17,6 @@ func createTestConfig() *models.Config {
 	cfg := &models.Config{}
 	cfg.General.Language = "en"
 	cfg.General.WhisperModel = "small-q5_1"
-	// TODO: Next feature - VAD implementation
-	// cfg.Audio.VADSensitivity = "medium"
-	// cfg.Audio.EnableVAD = false
 	cfg.Notifications.EnableWorkflowNotifications = true
 	return cfg
 }
@@ -154,8 +151,6 @@ func TestConfigService_ResetToDefaults(t *testing.T) {
 	service := NewConfigService(mockLogger, testConfig, tempFile.Name())
 	// Modify some settings first
 	service.config.General.Language = "fr"
-	// TODO: Next feature - VAD implementation
-	// service.config.Audio.EnableVAD = true
 
 	if err := service.ResetToDefaults(); err != nil {
 		t.Errorf("ResetToDefaults failed: %v", err)
@@ -164,10 +159,6 @@ func TestConfigService_ResetToDefaults(t *testing.T) {
 	if service.config.General.Language != "en" {
 		t.Error("Language should be reset to default 'en'")
 	}
-	// TODO: Next feature - VAD implementation
-	// if service.config.Audio.EnableVAD != false {
-	//	t.Error("EnableVAD should be reset to default false")
-	// }
 }
 
 func TestConfigService_Shutdown(t *testing.T) {

--- a/internal/services/factory_components.go
+++ b/internal/services/factory_components.go
@@ -171,9 +171,6 @@ func (cf *FactoryComponents) createHotkeyManager() *manager.HotkeyManager {
 	}
 	configAdapter := adapters.NewConfigAdapter(cf.config.Config.Hotkeys.StartRecording, cf.config.Config.Hotkeys.Provider).
 		WithAdditionalHotkeys(
-			// TODO: Next feature - VAD implementation
-			// cf.config.Config.Hotkeys.ToggleVAD,
-			"", // VAD hotkey placeholder
 			cf.config.Config.Hotkeys.ShowConfig,
 			cf.config.Config.Hotkeys.ResetToDefaults,
 		)

--- a/internal/services/factory_components.go
+++ b/internal/services/factory_components.go
@@ -185,29 +185,8 @@ func (cf *FactoryComponents) createWebSocketServer(recorder interfaces.AudioReco
 	return websocket.NewWebSocketServer(cf.config.Config, recorder, whisperEngine, cf.config.Logger)
 }
 
-// createTrayManager creates system tray manager
-// Placeholder Callbacks - real callbacks wired later in Stage 3 (CallbackWirer)
-// This allows tray to be created before services are assembled
+// createTrayManager creates system tray manager.
+// Callbacks are wired later in Stage 3 (FactoryWirer).
 func (cf *FactoryComponents) createTrayManager() tray.TrayManagerInterface {
-	return tray.CreateTrayManagerWithConfig(cf.config.Config,
-		cf.config.Logger,
-		func() { // onExit
-			cf.config.Logger.Info("Exit requested from tray")
-		},
-		func() error { // onToggle
-			cf.config.Logger.Info("Toggle requested from tray")
-			return nil
-		},
-		func() error { // onShowConfig
-			cf.config.Logger.Info("Show config requested from tray")
-			return nil
-		},
-		func() error { // onShowAbout
-			cf.config.Logger.Info("Show about requested from tray")
-			return nil
-		},
-		func() error { // onResetToDefaults
-			cf.config.Logger.Info("Reset to defaults requested from tray")
-			return nil
-		})
+	return tray.CreateTrayManagerWithConfig(cf.config.Config, cf.config.Logger)
 }

--- a/internal/services/factory_wirer.go
+++ b/internal/services/factory_wirer.go
@@ -65,7 +65,7 @@ func (cw *FactoryWirer) Wire(container *ServiceContainer, components *Components
 		cw.makeOutputModeCallback(container),
 	)
 	// Step 4: Dynamic queries (output tools, capture once support)
-	components.TrayManager.SetGetOutputToolsCallback(cw.makeGetOutputToolsCallback(container))
+	components.TrayManager.OutputToolsCallback(cw.makeGetOutputToolsCallback(container))
 	components.TrayManager.SetCaptureOnceSupport(cw.makeCaptureOnceSupportCallback(container))
 	// Step 5: UI sync (update tray menu with current settings)
 	cw.updateTraySettings(container, components.TrayManager)

--- a/internal/services/factory_wirer.go
+++ b/internal/services/factory_wirer.go
@@ -234,7 +234,7 @@ func (cw *FactoryWirer) makeConfigProvider(container *ServiceContainer) func() a
 			return adapters.NewConfigAdapter("", "auto")
 		}
 		return adapters.NewConfigAdapter(cfg.Hotkeys.StartRecording, cfg.Hotkeys.Provider).
-			WithAdditionalHotkeys("", cfg.Hotkeys.ShowConfig, cfg.Hotkeys.ResetToDefaults)
+			WithAdditionalHotkeys(cfg.Hotkeys.ShowConfig, cfg.Hotkeys.ResetToDefaults)
 	}
 }
 func (cw *FactoryWirer) updateUISettings(container *ServiceContainer) {

--- a/internal/services/hotkey_service.go
+++ b/internal/services/hotkey_service.go
@@ -44,8 +44,6 @@ func NewHotkeyService(
 func (hs *HotkeyService) SetupHotkeyCallbacks(
 	startRecording func() error,
 	stopRecording func() error,
-	// toggleVAD is the callback for toggling VAD
-	// toggleVAD func() error,
 	showConfig func() error,
 	resetToDefaults func() error,
 ) error {
@@ -56,8 +54,6 @@ func (hs *HotkeyService) SetupHotkeyCallbacks(
 	// Register the main recording callbacks
 	hs.hotkeyManager.RegisterCallbacks(startRecording, stopRecording)
 	// Register additional hotkey actions
-	// TODO: Next feature - VAD implementation
-	// hs.hotkeyManager.RegisterHotkeyAction("toggle_vad", toggleVAD)
 	hs.hotkeyManager.RegisterHotkeyAction("show_config", showConfig)
 	hs.hotkeyManager.RegisterHotkeyAction("reset_to_defaults", resetToDefaults)
 	hs.logger.Info("Hotkey callbacks configured successfully")

--- a/internal/services/interfaces.go
+++ b/internal/services/interfaces.go
@@ -24,10 +24,6 @@ type AudioServiceInterface interface {
 	// Transcript access
 	GetLastTranscript() string
 
-	// TODO: Next feature - VAD implementation
-	// VAD (Voice Activity Detection) operations
-	// HandleStartVADRecording() error
-
 	// Cleanup
 	Shutdown() error
 }
@@ -83,9 +79,6 @@ type ConfigServiceInterface interface {
 	GetConfig() *config.Config
 
 	// Settings updates
-	// TODO: Next feature - VAD implementation
-	// UpdateVADSensitivity(sensitivity string) error
-	// ToggleVAD() error
 	UpdateLanguage(language string) error
 	ToggleWorkflowNotifications() error
 	UpdateRecordingMethod(method string) error
@@ -102,7 +95,6 @@ type HotkeyServiceInterface interface {
 	SetupHotkeyCallbacks(
 		startRecording func() error,
 		stopRecording func() error,
-		// toggleVAD func() error,
 		showConfig func() error,
 		reloadConfig func() error,
 	) error

--- a/internal/tray/default_manager.go
+++ b/internal/tray/default_manager.go
@@ -11,15 +11,15 @@ import (
 )
 
 // CreateDefaultTrayManager creates the default tray manager
-// based on available dependencies
-func CreateDefaultTrayManager(logger logger.Logger, onExit func(), onToggle func() error, onShowConfig func() error, onShowAbout func() error, onResetToDefaults func() error) TrayManagerInterface {
+// based on available dependencies.
+func CreateDefaultTrayManager(logger logger.Logger) TrayManagerInterface {
 	// Use the mock implementation as fallback when systray is not available
-	return CreateMockTrayManager(logger, onExit, onToggle, onShowConfig, onShowAbout, onResetToDefaults)
+	return CreateMockTrayManager(logger)
 }
 
-// CreateTrayManagerWithConfig creates tray manager with initial configuration
-func CreateTrayManagerWithConfig(config *config.Config, logger logger.Logger, onExit func(), onToggle func() error, onShowConfig func() error, onShowAbout func() error, onResetToDefaults func() error) TrayManagerInterface {
-	trayManager := CreateDefaultTrayManager(logger, onExit, onToggle, onShowConfig, onShowAbout, onResetToDefaults)
+// CreateTrayManagerWithConfig creates tray manager with initial configuration.
+func CreateTrayManagerWithConfig(config *config.Config, logger logger.Logger) TrayManagerInterface {
+	trayManager := CreateDefaultTrayManager(logger)
 	trayManager.UpdateSettings(config)
 	return trayManager
 }

--- a/internal/tray/default_systray.go
+++ b/internal/tray/default_systray.go
@@ -6,30 +6,23 @@
 package tray
 
 import (
-	"os"
-	"path/filepath"
-
 	"github.com/AshBuk/speak-to-ai/config"
 	"github.com/AshBuk/speak-to-ai/internal/logger"
 )
 
 // CreateDefaultTrayManager creates the default tray manager
-// based on available dependencies
-func CreateDefaultTrayManager(logger logger.Logger, onExit func(), onToggle func() error, onShowConfig func() error, onShowAbout func() error, onResetToDefaults func() error) TrayManagerInterface {
+// based on available dependencies.
+func CreateDefaultTrayManager(logger logger.Logger) TrayManagerInterface {
 	// Use the real systray implementation
 	iconMicOff := GetIconMicOff(logger)
 	iconMicOn := GetIconMicOn(logger)
 
-	// Try to detect AppImage dir (reserved for potential icon overrides)
-	_ = os.Getenv("APPDIR")
-	_ = filepath.Join
-
-	return NewTrayManager(iconMicOff, iconMicOn, onExit, onToggle, onShowConfig, onShowAbout, onResetToDefaults, logger)
+	return NewTrayManager(iconMicOff, iconMicOn, logger)
 }
 
-// CreateTrayManagerWithConfig creates tray manager with initial configuration
-func CreateTrayManagerWithConfig(config *config.Config, logger logger.Logger, onExit func(), onToggle func() error, onShowConfig func() error, onShowAbout func() error, onResetToDefaults func() error) TrayManagerInterface {
-	trayManager := CreateDefaultTrayManager(logger, onExit, onToggle, onShowConfig, onShowAbout, onResetToDefaults)
+// CreateTrayManagerWithConfig creates tray manager with initial configuration.
+func CreateTrayManagerWithConfig(config *config.Config, logger logger.Logger) TrayManagerInterface {
+	trayManager := CreateDefaultTrayManager(logger)
 	trayManager.UpdateSettings(config)
 	return trayManager
 }

--- a/internal/tray/interface.go
+++ b/internal/tray/interface.go
@@ -18,9 +18,8 @@ type TrayManagerInterface interface {
 	SetAudioActions(onSelectRecorder func(method string) error)
 	// SetHotkeyRebindAction sets callback to rebind hotkeys by action name
 	SetHotkeyRebindAction(onRebind func(action string) error)
-	// SetSettingsActions sets callbacks for general settings from tray (VAD, Language, Notifications)
+	// SetSettingsActions sets callbacks for general settings from tray (Language, Notifications)
 	SetSettingsActions(
-		// onSelectVADSensitivity func(sensitivity string) error,
 		onSelectLanguage func(language string) error,
 		onToggleWorkflowNotifications func() error,
 		onSelectOutputMode func(mode string) error,

--- a/internal/tray/interface.go
+++ b/internal/tray/interface.go
@@ -25,8 +25,8 @@ type TrayManagerInterface interface {
 		onToggleWorkflowNotifications func() error,
 		onSelectOutputMode func(mode string) error,
 	)
-	// SetGetOutputToolsCallback sets the callback for getting actual output tool names
-	SetGetOutputToolsCallback(callback func() (clipboardTool, typeTool string))
+	// OutputToolsCallback sets the callback for getting actual output tool names
+	OutputToolsCallback(callback func() (clipboardTool, typeTool string))
 	// SetCaptureOnceSupport sets a callback indicating whether capture once is supported
 	SetCaptureOnceSupport(callback func() bool)
 	Stop()

--- a/internal/tray/mock_tray.go
+++ b/internal/tray/mock_tray.go
@@ -10,16 +10,14 @@ import (
 
 // MockTrayManager implements a mock version of TrayManager without external dependencies
 type MockTrayManager struct {
-	isRecording       bool
-	logger            logger.Logger
-	onExit            func()
-	onToggle          func() error
-	onShowConfig      func() error
-	onShowAbout       func() error
-	onResetToDefaults func() error
-	onSelectRecorder  func(method string) error
-	// onSelectVADSens is the callback for VAD sensitivity selection
-	// onSelectVADSens        func(sensitivity string) error
+	isRecording            bool
+	logger                 logger.Logger
+	onExit                 func()
+	onToggle               func() error
+	onShowConfig           func() error
+	onShowAbout            func() error
+	onResetToDefaults      func() error
+	onSelectRecorder       func(method string) error
 	onSelectLang           func(language string) error
 	onToggleWorkflowNotify func() error
 	onGetOutputTools       func() (clipboardTool, typeTool string)
@@ -79,12 +77,10 @@ func (tm *MockTrayManager) SetAudioActions(onSelectRecorder func(method string) 
 
 // SetSettingsActions sets callbacks for settings (mock implementation)
 func (tm *MockTrayManager) SetSettingsActions(
-	// onSelectVADSensitivity func(sensitivity string) error,
 	onSelectLanguage func(language string) error,
 	onToggleWorkflowNotifications func() error,
 	onSelectOutputMode func(mode string) error,
 ) {
-	// tm.onSelectVADSens = onSelectVADSensitivity
 	tm.onSelectLang = onSelectLanguage
 	tm.onToggleWorkflowNotify = onToggleWorkflowNotifications
 	tm.onSelectOutputMode = onSelectOutputMode

--- a/internal/tray/mock_tray.go
+++ b/internal/tray/mock_tray.go
@@ -91,8 +91,8 @@ func (tm *MockTrayManager) SetSettingsActions(
 	tm.logger.Info("Mock tray: settings actions set")
 }
 
-// SetGetOutputToolsCallback sets the callback for getting actual output tool names (mock implementation)
-func (tm *MockTrayManager) SetGetOutputToolsCallback(callback func() (clipboardTool, typeTool string)) {
+// OutputToolsCallback sets the callback for getting actual output tool names (mock implementation)
+func (tm *MockTrayManager) OutputToolsCallback(callback func() (clipboardTool, typeTool string)) {
 	tm.onGetOutputTools = callback
 	tm.logger.Info("Mock tray: get output tools callback set")
 }

--- a/internal/tray/mock_tray.go
+++ b/internal/tray/mock_tray.go
@@ -26,16 +26,11 @@ type MockTrayManager struct {
 	onSelectOutputMode     func(mode string) error
 }
 
-// CreateMockTrayManager creates a mock tray manager that doesn't use systray
-func CreateMockTrayManager(logger logger.Logger, onExit func(), onToggle func() error, onShowConfig func() error, onShowAbout func() error, onResetToDefaults func() error) TrayManagerInterface {
+// CreateMockTrayManager creates a mock tray manager that doesn't use systray.
+// Callbacks are wired later via setter methods.
+func CreateMockTrayManager(logger logger.Logger) TrayManagerInterface {
 	return &MockTrayManager{
-		isRecording:       false,
-		logger:            logger,
-		onExit:            onExit,
-		onToggle:          onToggle,
-		onShowConfig:      onShowConfig,
-		onShowAbout:       onShowAbout,
-		onResetToDefaults: onResetToDefaults,
+		logger: logger,
 	}
 }
 

--- a/internal/tray/settings_menu.go
+++ b/internal/tray/settings_menu.go
@@ -16,12 +16,6 @@ func (tm *TrayManager) createSettingsSubmenus() {
 	tm.audioRecorderMenu = tm.settingsItem.AddSubMenuItem("Audio Recorder", "Select audio recorder")
 	tm.languageMenu = tm.settingsItem.AddSubMenuItem("Set Language", "Select recognition language")
 
-	// VAD Sensitivity submenu
-	// vadMenu := tm.settingsItem.AddSubMenuItem("VAD Sensitivity", "Select VAD sensitivity level")
-	// tm.audioItems["vad_low"] = vadMenu.AddSubMenuItem("○ Low", "Low sensitivity")
-	// tm.audioItems["vad_medium"] = vadMenu.AddSubMenuItem("○ Medium", "Medium sensitivity")
-	// tm.audioItems["vad_high"] = vadMenu.AddSubMenuItem("○ High", "High sensitivity")
-
 	tm.outputMenu = tm.settingsItem.AddSubMenuItem("Output", "Output settings")
 
 	// Populate with initial values if config is available
@@ -323,30 +317,6 @@ func (tm *TrayManager) updateRecorderRadioUI(method string) {
 		ffmpegItem.SetTitle("○ ffmpeg (PulseAudio)")
 	}
 }
-
-// updateVADRadioUI updates VAD sensitivity radio titles
-// func (tm *TrayManager) updateVADRadioUI(level string) {
-// 	low := tm.audioItems["vad_low"]
-// 	med := tm.audioItems["vad_medium"]
-// 	high := tm.audioItems["vad_high"]
-// 	if low == nil || med == nil || high == nil {
-// 		return
-// 	}
-// 	switch level {
-// 	case "low":
-// 		low.SetTitle("● Low")
-// 		med.SetTitle("○ Medium")
-// 		high.SetTitle("○ High")
-// 	case "high":
-// 		high.SetTitle("● High")
-// 		low.SetTitle("○ Low")
-// 		med.SetTitle("○ Medium")
-// 	default:
-// 		med.SetTitle("● Medium")
-// 		low.SetTitle("○ Low")
-// 		high.SetTitle("○ High")
-// 	}
-// }
 
 // updateLanguageRadioUI updates selection marks for language menu
 func (tm *TrayManager) updateLanguageRadioUI(lang string) {

--- a/internal/tray/settings_menu.go
+++ b/internal/tray/settings_menu.go
@@ -55,20 +55,28 @@ func (tm *TrayManager) setupAudioRecorderMenu() {
 		"Use ffmpeg (PulseAudio)",
 	)
 
-	// Set up click handlers
+	// Set up click handlers.
+	// Use closure to read tm.onSelectRecorder at invocation time (not capture time),
+	// because callbacks are wired after tray setup via setter methods.
+	recorderCb := func(method string) error {
+		if tm.onSelectRecorder != nil {
+			return tm.onSelectRecorder(method)
+		}
+		return nil
+	}
 	tm.handleRadioItemClick(
 		tm.audioItems["recorder_arecord"],
 		"arecord",
 		"Audio recorder switched to %s (UI)",
 		tm.updateRecorderRadioUI,
-		tm.onSelectRecorder,
+		recorderCb,
 	)
 	tm.handleRadioItemClick(
 		tm.audioItems["recorder_ffmpeg"],
 		"ffmpeg",
 		"Audio recorder switched to %s (UI)",
 		tm.updateRecorderRadioUI,
-		tm.onSelectRecorder,
+		recorderCb,
 	)
 
 	// Update initial UI state
@@ -91,6 +99,14 @@ func (tm *TrayManager) setupLanguageMenu() {
 	)
 	tm.languageItems["current"].Disable()
 
+	// Use closure to read tm.onSelectLang at invocation time (not capture time)
+	langCb := func(code string) error {
+		if tm.onSelectLang != nil {
+			return tm.onSelectLang(code)
+		}
+		return nil
+	}
+
 	// Flat list of all languages (GNOME-compatible, 3 levels: Settings > Set Language > Language)
 	for _, lang := range constants.WhisperLanguages {
 		indicator := "○ "
@@ -106,7 +122,7 @@ func (tm *TrayManager) setupLanguageMenu() {
 			langCode,
 			"Language switched to %s (UI)",
 			tm.updateLanguageRadioUI,
-			tm.onSelectLang,
+			langCb,
 		)
 	}
 }
@@ -146,7 +162,14 @@ func (tm *TrayManager) setupOutputMenu() {
 	)
 	tm.outputItems["type_tool"].Disable()
 
-	// Set up click handlers
+	// Set up click handlers.
+	// Use closure to read tm.onSelectOutputMode at invocation time (not capture time)
+	outputCb := func(mode string) error {
+		if tm.onSelectOutputMode != nil {
+			return tm.onSelectOutputMode(mode)
+		}
+		return nil
+	}
 	for _, k := range []string{"clipboard", "active_window"} {
 		if itm := tm.outputItems["mode_"+k]; itm != nil {
 			key := k
@@ -155,7 +178,7 @@ func (tm *TrayManager) setupOutputMenu() {
 				key,
 				"Output mode switched to %s (UI)",
 				tm.updateOutputModeRadioUI,
-				tm.onSelectOutputMode,
+				outputCb,
 			)
 		}
 	}

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -267,8 +267,8 @@ func (tm *TrayManager) SetHotkeyRebindAction(onRebind func(action string) error)
 	tm.onRebindHotkey = onRebind
 }
 
-// SetGetOutputToolsCallback sets the callback for getting actual output tool names
-func (tm *TrayManager) SetGetOutputToolsCallback(callback func() (clipboardTool, typeTool string)) {
+// OutputToolsCallback sets the callback for getting actual output tool names
+func (tm *TrayManager) OutputToolsCallback(callback func() (clipboardTool, typeTool string)) {
 	tm.onGetOutputTools = callback
 }
 

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -52,8 +52,6 @@ type TrayManager struct {
 	// Audio action callbacks
 	onSelectRecorder func(method string) error
 	// Settings callbacks
-	// onSelectVADSens sets the callback for VAD sensitivity selection.
-	// onSelectVADSens        func(sensitivity string) error
 	onSelectLang           func(language string) error
 	onToggleWorkflowNotify func() error
 	onGetOutputTools       func() (clipboardTool, typeTool string)
@@ -156,8 +154,6 @@ func (tm *TrayManager) UpdateSettings(config *config.Config) {
 	tm.updateHotkeysMenuUI()
 	// The helpers gracefully no-op if items are not yet created
 	tm.updateRecorderRadioUI(config.Audio.RecordingMethod)
-	// TODO: Next feature - VAD implementation
-	// tm.updateVADRadioUI(config.Audio.VADSensitivity)
 	tm.updateLanguageRadioUI(config.General.Language)
 	tm.updateWorkflowNotificationUI(config.Notifications.EnableWorkflowNotifications)
 	tm.updateOutputUI()
@@ -251,12 +247,10 @@ func (tm *TrayManager) SetExitAction(onExit func()) {
 
 // SetSettingsActions sets callbacks for general settings
 func (tm *TrayManager) SetSettingsActions(
-	// onSelectVADSensitivity func(sensitivity string) error,
 	onSelectLanguage func(language string) error,
 	onToggleWorkflowNotifications func() error,
 	onSelectOutputMode func(mode string) error,
 ) {
-	// tm.onSelectVADSens = onSelectVADSensitivity
 	tm.onSelectLang = onSelectLanguage
 	tm.onToggleWorkflowNotify = onToggleWorkflowNotifications
 	tm.onSelectOutputMode = onSelectOutputMode

--- a/tests/mocks/hotkey_manager.go
+++ b/tests/mocks/hotkey_manager.go
@@ -29,10 +29,8 @@ type MockHotkeyManager struct {
 	registerHotkeyActionCalled map[string]bool
 	startError                 error
 	callbacks                  struct {
-		startRecording func() error
-		stopRecording  func() error
-		// TODO: Next feature - VAD implementation
-		// toggleVAD       manager.HotkeyAction
+		startRecording  func() error
+		stopRecording   func() error
 		showConfig      manager.HotkeyAction
 		resetToDefaults manager.HotkeyAction
 	}
@@ -60,9 +58,6 @@ func (m *MockHotkeyManager) RegisterHotkeyAction(action string, callback manager
 	m.registerHotkeyActionCalled[action] = true
 
 	switch action {
-	// TODO: Next feature - VAD implementation
-	// case "toggle_vad":
-	//	m.callbacks.toggleVAD = callback
 	case "show_config":
 		m.callbacks.showConfig = callback
 	case "reset_to_defaults":
@@ -101,11 +96,6 @@ func (m *MockHotkeyManager) TriggerCallback(callbackType string) error {
 		if m.callbacks.resetToDefaults != nil {
 			return m.callbacks.resetToDefaults()
 		}
-		// TODO: Next feature - VAD implementation
-		// case "toggleVAD":
-		// 	if m.callbacks.toggleVAD != nil {
-		// 		return m.callbacks.toggleVAD()
-		// 	}
 	}
 	return nil
 }

--- a/tests/mocks/services.go
+++ b/tests/mocks/services.go
@@ -27,9 +27,6 @@ func (m *MockAudioService) IsRecording() bool           { return false }
 func (m *MockAudioService) ClearSession()               {}
 func (m *MockAudioService) GetLastTranscript() string   { return "" }
 
-// TODO: Next feature - VAD implementation
-// func (m *MockAudioService) HandleStartVADRecording() error                  { return nil }
-
 // Test helper methods
 func (m *MockAudioService) WasShutdownCalled() bool { return m.shutdownCalled }
 
@@ -101,13 +98,8 @@ func (m *MockConfigService) SaveConfig() error                  { return nil }
 func (m *MockConfigService) ResetToDefaults() error             { return nil }
 func (m *MockConfigService) GetConfig() *config.Config          { return &config.Config{} }
 
-// TODO: Next feature - VAD implementation
-// func (m *MockConfigService) UpdateVADSensitivity(sensitivity string) error { return nil }
-func (m *MockConfigService) UpdateLanguage(language string) error { return nil }
-func (m *MockConfigService) ToggleWorkflowNotifications() error   { return nil }
-
-// TODO: Next feature - VAD implementation
-// func (m *MockConfigService) ToggleVAD() error                              { return nil }
+func (m *MockConfigService) UpdateLanguage(language string) error      { return nil }
+func (m *MockConfigService) ToggleWorkflowNotifications() error        { return nil }
 func (m *MockConfigService) UpdateRecordingMethod(method string) error { return nil }
 func (m *MockConfigService) UpdateOutputMode(mode string) error        { return nil }
 func (m *MockConfigService) UpdateHotkey(action, combo string) error   { return nil }
@@ -131,8 +123,6 @@ func (m *MockHotkeyService) Shutdown() error {
 func (m *MockHotkeyService) SetupHotkeyCallbacks(
 	startRecording func() error,
 	stopRecording func() error,
-	// TODO: Next feature - VAD implementation
-	// toggleVAD func() error,
 	showConfig func() error,
 	resetToDefaults func() error,
 ) error {


### PR DESCRIPTION
Decouple TrayManager callbacks from constructors - all callbacks are now wired exclusively via setter methods, eliminating placeholder stubs. 
Remove dead commented-out VAD code across the codebase.