### PR TITLE
Concurrency/race safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.3] - 2026-02-23
+
+### Fixes
+- **Hotkey stability:** Fix potential crash on rapid hotkey provider restart during configuration changes
+
+### Maintenance
+- **Tray refactor:** Decouple callbacks from constructors — all wired via setter methods ([#74](https://github.com/AshBuk/speak-to-ai/pull/74))
+- **Dead code cleanup:** Remove unused VAD commented-out code across codebase ([#74](https://github.com/AshBuk/speak-to-ai/pull/74))
+- **Race safety:** Add mutex protection to test utilities, fix concurrent test callbacks
+
+---
 ## [1.6.2] - 2026-02-07
 
 ### Features

--- a/hotkeys/manager/manager_test.go
+++ b/hotkeys/manager/manager_test.go
@@ -361,7 +361,9 @@ func TestHotkeyManager_ConcurrentAccess(t *testing.T) {
 
 	go func() {
 		for i := 0; i < 100; i++ {
+			manager.hotkeysMutex.Lock()
 			manager.isRecording = i%2 == 0
+			manager.hotkeysMutex.Unlock()
 		}
 		done <- true
 	}()

--- a/internal/testutils/mock_logger.go
+++ b/internal/testutils/mock_logger.go
@@ -3,10 +3,14 @@
 
 package testutils
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
 // MockLogger implements Logger interface for testing
 type MockLogger struct {
+	mu       sync.Mutex
 	messages []string
 }
 
@@ -19,35 +23,51 @@ func NewMockLogger() *MockLogger {
 
 // Debug logs a debug message
 func (m *MockLogger) Debug(format string, args ...interface{}) {
+	m.mu.Lock()
 	m.messages = append(m.messages, fmt.Sprintf("[DEBUG] "+format, args...))
+	m.mu.Unlock()
 }
 
 // Info logs an info message
 func (m *MockLogger) Info(format string, args ...interface{}) {
+	m.mu.Lock()
 	m.messages = append(m.messages, fmt.Sprintf("[INFO] "+format, args...))
+	m.mu.Unlock()
 }
 
 // Warning logs a warning message
 func (m *MockLogger) Warning(format string, args ...interface{}) {
+	m.mu.Lock()
 	m.messages = append(m.messages, fmt.Sprintf("[WARNING] "+format, args...))
+	m.mu.Unlock()
 }
 
 // Error logs an error message
 func (m *MockLogger) Error(format string, args ...interface{}) {
+	m.mu.Lock()
 	m.messages = append(m.messages, fmt.Sprintf("[ERROR] "+format, args...))
+	m.mu.Unlock()
 }
 
 // Fatal logs a fatal message
 func (m *MockLogger) Fatal(format string, args ...interface{}) {
+	m.mu.Lock()
 	m.messages = append(m.messages, fmt.Sprintf("[FATAL] "+format, args...))
+	m.mu.Unlock()
 }
 
 // GetMessages returns all logged messages
 func (m *MockLogger) GetMessages() []string {
-	return m.messages
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	copied := make([]string, len(m.messages))
+	copy(copied, m.messages)
+	return copied
 }
 
 // Clear clears all logged messages
 func (m *MockLogger) Clear() {
+	m.mu.Lock()
 	m.messages = m.messages[:0]
+	m.mu.Unlock()
 }

--- a/io.github.ashbuk.speak-to-ai.appdata.xml
+++ b/io.github.ashbuk.speak-to-ai.appdata.xml
@@ -43,6 +43,11 @@
     <binary>speak-to-ai</binary>
   </provides>
   <releases>
+    <release version="1.6.3" date="2026-02-23">
+      <description>
+        <p>Fix potential crash on rapid hotkey restart. Tray refactor, dead code cleanup.</p>
+      </description>
+    </release>
     <release version="1.6.2" date="2026-02-07">
       <description>
         <p>CLI toggle command for one-key voice input. XDG config compliance.</p>

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -2,7 +2,7 @@
 # https://github.com/AshBuk/speak-to-ai
 
 pkgname=speak-to-ai
-pkgver=1.6.2
+pkgver=1.6.3
 pkgrel=1
 pkgdesc="Offline speech-to-text desktop application using Whisper"
 arch=('x86_64')

--- a/packaging/fedora/speak-to-ai.spec
+++ b/packaging/fedora/speak-to-ai.spec
@@ -5,7 +5,7 @@
 # =============================================================================
 # Version definitions (single source of truth)
 # =============================================================================
-%global app_version     1.6.2
+%global app_version     1.6.3
 %global go_version      1.21
 %global whisper_version 1.8.3
 
@@ -257,6 +257,9 @@ fi
 %{_datadir}/icons/hicolor/scalable/apps/io.github.ashbuk.speak-to-ai.svg
 
 %changelog
+* Mon Feb 23 2026 Asher Buk <AshBuk@users.noreply.github.com> - 1.6.3-1
+- Fix potential crash on rapid hotkey restart, tray refactor, dead code cleanup
+
 * Sat Feb 07 2026 Asher Buk <AshBuk@users.noreply.github.com> - 1.6.2-1
 - CLI toggle command, XDG config compliance
 


### PR DESCRIPTION
Fix data races detected by go test -race: evdev provider WaitGroup/channel races on rapid restart, unsynchronized mock utilities, and unprotected shared state in test callbacks.

go test -race -count=3 passes on all packages with 0 races