### PR TITLE
Whisper/model selection

### DIFF
--- a/config/validators/standard_validator.go
+++ b/config/validators/standard_validator.go
@@ -10,14 +10,15 @@ import (
 	"strings"
 
 	"github.com/AshBuk/speak-to-ai/config/models"
+	"github.com/AshBuk/speak-to-ai/internal/constants"
 )
 
 // validateGeneralConfig validates general configuration settings
 func validateGeneralConfig(config *models.Config, errors *[]string) {
-	// The whisper model is fixed to a specific version for consistency
-	if config.General.WhisperModel != "small-q5_1" {
-		*errors = append(*errors, fmt.Sprintf("invalid whisper model: %s, using 'small-q5_1'", config.General.WhisperModel))
-		config.General.WhisperModel = "small-q5_1"
+	// Validate whisper model against known model IDs
+	if constants.ModelByID(config.General.WhisperModel) == nil {
+		*errors = append(*errors, fmt.Sprintf("invalid whisper model: %s, using '%s'", config.General.WhisperModel, constants.DefaultModelID))
+		config.General.WhisperModel = constants.DefaultModelID
 	}
 
 	if config.General.TempAudioPath != "" {

--- a/internal/constants/models.go
+++ b/internal/constants/models.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
+package constants
+
+// DefaultModelID is the default whisper model used when none is configured
+const DefaultModelID = "small-q5_1"
+
+// WhisperModelDef describes an available whisper model variant
+type WhisperModelDef struct {
+	ID       string // Unique identifier (matches config value)
+	Name     string // Human-readable name for UI
+	FileName string // File name on disk
+	URL      string // HuggingFace download URL
+	MinSize  int64  // Minimum valid file size in bytes
+}
+
+// WhisperModels contains curated quantized whisper models for machines with varying GPU compute power
+var WhisperModels = []WhisperModelDef{
+	{
+		ID:       "base-q5_1",
+		Name:     "Base (Q5_1)",
+		FileName: "ggml-base-q5_1.bin",
+		URL:      "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base-q5_1.bin",
+		MinSize:  50 * 1024 * 1024, // ~57 MB
+	},
+	{
+		ID:       "small-q5_1",
+		Name:     "Small (Q5_1)",
+		FileName: "small-q5_1.bin",
+		URL:      "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small-q5_1.bin",
+		MinSize:  150 * 1024 * 1024, // ~181 MB
+	},
+	{
+		ID:       "medium-q5_0",
+		Name:     "Medium (Q5_0)",
+		FileName: "ggml-medium-q5_0.bin",
+		URL:      "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium-q5_0.bin",
+		MinSize:  500 * 1024 * 1024, // ~539 MB
+	},
+	{
+		ID:       "large-q5_0",
+		Name:     "Large (Q5_0)",
+		FileName: "ggml-large-q5_0.bin",
+		URL:      "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-q5_0.bin",
+		MinSize:  1000 * 1024 * 1024, // ~1.1 GB
+	},
+}
+
+// ModelByID returns model definition by its ID, or nil if not found
+func ModelByID(id string) *WhisperModelDef {
+	for _, m := range WhisperModels {
+		if m.ID == id {
+			return &m
+		}
+	}
+	return nil
+}

--- a/internal/services/config_service.go
+++ b/internal/services/config_service.go
@@ -81,6 +81,21 @@ func (cs *ConfigService) GetConfig() *config.Config {
 	return cs.config
 }
 
+// Change whisper model setting with rollback on save failure
+func (cs *ConfigService) UpdateWhisperModel(modelID string) error {
+	cs.logger.Info("Updating whisper model to: %s", modelID)
+	if cs.config.General.WhisperModel == modelID {
+		return nil
+	}
+	old := cs.config.General.WhisperModel
+	cs.config.General.WhisperModel = modelID
+	if err := cs.SaveConfig(); err != nil {
+		cs.config.General.WhisperModel = old
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+	return nil
+}
+
 // Change whisper language setting with rollback on save failure
 func (cs *ConfigService) UpdateLanguage(language string) error {
 	cs.logger.Info("Updating language to: %s", language)

--- a/internal/services/interfaces.go
+++ b/internal/services/interfaces.go
@@ -21,6 +21,9 @@ type AudioServiceInterface interface {
 	// Session management
 	ClearSession()
 
+	// Model management
+	SwitchModel(modelID string) error
+
 	// Transcript access
 	GetLastTranscript() string
 
@@ -80,6 +83,7 @@ type ConfigServiceInterface interface {
 
 	// Settings updates
 	UpdateLanguage(language string) error
+	UpdateWhisperModel(modelID string) error
 	ToggleWorkflowNotifications() error
 	UpdateRecordingMethod(method string) error
 	UpdateOutputMode(mode string) error

--- a/internal/services/io_service.go
+++ b/internal/services/io_service.go
@@ -14,6 +14,7 @@ import (
 	outputFactory "github.com/AshBuk/speak-to-ai/output/factory"
 	outputInterfaces "github.com/AshBuk/speak-to-ai/output/interfaces"
 	"github.com/AshBuk/speak-to-ai/websocket"
+	"github.com/AshBuk/speak-to-ai/whisper"
 )
 
 // Handles text output routing and transcription synchronization
@@ -230,6 +231,13 @@ func (ios *IOService) detectOutputEnvironment() outputFactory.EnvironmentType {
 		return outputFactory.EnvironmentX11
 	default:
 		return outputFactory.EnvironmentUnknown
+	}
+}
+
+// SetWhisperEngine updates the WebSocket server's whisper engine reference after hot-reload
+func (ios *IOService) SetWhisperEngine(engine *whisper.WhisperEngine) {
+	if ios.webSocketServer != nil {
+		ios.webSocketServer.SetWhisperEngine(engine)
 	}
 }
 

--- a/internal/tray/interface.go
+++ b/internal/tray/interface.go
@@ -16,6 +16,8 @@ type TrayManagerInterface interface {
 	SetCoreActions(onToggle func() error, onShowConfig func() error, onShowAbout func() error, onResetToDefaults func() error)
 	// SetAudioActions sets callbacks for audio-related actions
 	SetAudioActions(onSelectRecorder func(method string) error)
+	// SetModelAction sets callback for whisper model selection
+	SetModelAction(onSelectModel func(modelID string) error)
 	// SetHotkeyRebindAction sets callback to rebind hotkeys by action name
 	SetHotkeyRebindAction(onRebind func(action string) error)
 	// SetSettingsActions sets callbacks for general settings from tray (Language, Notifications)

--- a/internal/tray/mock_tray.go
+++ b/internal/tray/mock_tray.go
@@ -98,6 +98,11 @@ func (tm *MockTrayManager) SetCaptureOnceSupport(callback func() bool) {
 	tm.logger.Info("Mock tray: capture once support callback set")
 }
 
+// SetModelAction sets callback for whisper model selection (mock)
+func (tm *MockTrayManager) SetModelAction(onSelectModel func(modelID string) error) {
+	tm.logger.Info("Mock tray: model action set")
+}
+
 // SetHotkeyRebindAction sets callback for hotkey rebind (mock)
 func (tm *MockTrayManager) SetHotkeyRebindAction(onRebind func(action string) error) {
 	tm.logger.Info("Mock tray: hotkey rebind action set")

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -41,16 +41,19 @@ type TrayManager struct {
 	hotkeysMenu       *systray.MenuItem
 	audioRecorderMenu *systray.MenuItem
 	languageMenu      *systray.MenuItem
+	modelMenu         *systray.MenuItem
 	outputMenu        *systray.MenuItem
 
 	// Dynamic settings items
 	hotkeyItems   map[string]*systray.MenuItem
 	audioItems    map[string]*systray.MenuItem
 	languageItems map[string]*systray.MenuItem
+	modelItems    map[string]*systray.MenuItem
 	outputItems   map[string]*systray.MenuItem
 
 	// Audio action callbacks
 	onSelectRecorder func(method string) error
+	onSelectModel    func(modelID string) error
 	// Settings callbacks
 	onSelectLang           func(language string) error
 	onToggleWorkflowNotify func() error
@@ -76,6 +79,7 @@ func NewTrayManager(iconMicOff, iconMicOn []byte, logger logger.Logger) *TrayMan
 		hotkeyItems:   make(map[string]*systray.MenuItem),
 		audioItems:    make(map[string]*systray.MenuItem),
 		languageItems: make(map[string]*systray.MenuItem),
+		modelItems:    make(map[string]*systray.MenuItem),
 		outputItems:   make(map[string]*systray.MenuItem),
 		logger:        logger,
 	}
@@ -155,6 +159,7 @@ func (tm *TrayManager) UpdateSettings(config *config.Config) {
 	// The helpers gracefully no-op if items are not yet created
 	tm.updateRecorderRadioUI(config.Audio.RecordingMethod)
 	tm.updateLanguageRadioUI(config.General.Language)
+	tm.updateModelRadioUI(config.General.WhisperModel)
 	tm.updateWorkflowNotificationUI(config.Notifications.EnableWorkflowNotifications)
 	tm.updateOutputUI()
 }
@@ -238,6 +243,11 @@ func (tm *TrayManager) Stop() {
 // SetAudioActions sets callbacks for audio-related actions (recorder selection)
 func (tm *TrayManager) SetAudioActions(onSelectRecorder func(method string) error) {
 	tm.onSelectRecorder = onSelectRecorder
+}
+
+// SetModelAction sets callback for whisper model selection
+func (tm *TrayManager) SetModelAction(onSelectModel func(modelID string) error) {
+	tm.onSelectModel = onSelectModel
 }
 
 // SetExitAction allows overriding the exit callback (useful once services are wired)

--- a/tests/mocks/services.go
+++ b/tests/mocks/services.go
@@ -21,11 +21,12 @@ func (m *MockAudioService) Shutdown() error {
 	return m.shutdownError
 }
 
-func (m *MockAudioService) HandleStartRecording() error { return nil }
-func (m *MockAudioService) HandleStopRecording() error  { return nil }
-func (m *MockAudioService) IsRecording() bool           { return false }
-func (m *MockAudioService) ClearSession()               {}
-func (m *MockAudioService) GetLastTranscript() string   { return "" }
+func (m *MockAudioService) HandleStartRecording() error      { return nil }
+func (m *MockAudioService) HandleStopRecording() error       { return nil }
+func (m *MockAudioService) IsRecording() bool                { return false }
+func (m *MockAudioService) ClearSession()                    {}
+func (m *MockAudioService) SwitchModel(modelID string) error { return nil }
+func (m *MockAudioService) GetLastTranscript() string        { return "" }
 
 // Test helper methods
 func (m *MockAudioService) WasShutdownCalled() bool { return m.shutdownCalled }
@@ -99,6 +100,7 @@ func (m *MockConfigService) ResetToDefaults() error             { return nil }
 func (m *MockConfigService) GetConfig() *config.Config          { return &config.Config{} }
 
 func (m *MockConfigService) UpdateLanguage(language string) error      { return nil }
+func (m *MockConfigService) UpdateWhisperModel(modelID string) error   { return nil }
 func (m *MockConfigService) ToggleWorkflowNotifications() error        { return nil }
 func (m *MockConfigService) UpdateRecordingMethod(method string) error { return nil }
 func (m *MockConfigService) UpdateOutputMode(mode string) error        { return nil }

--- a/websocket/message_handler.go
+++ b/websocket/message_handler.go
@@ -87,7 +87,7 @@ func (s *WebSocketServer) handleStopRecording(conn *websocket.Conn, requestID st
 	ctx, cancel := context.WithTimeout(context.Background(), transcriptionCtxTimeout)
 	defer cancel()
 	go func() {
-		text, err := s.whisper.TranscribeWithContext(ctx, audioFile)
+		text, err := s.whisperEngine().TranscribeWithContext(ctx, audioFile)
 		resultCh <- transcriptionResult{text: text, err: err}
 	}()
 

--- a/whisper/interfaces/model_manager.go
+++ b/whisper/interfaces/model_manager.go
@@ -9,30 +9,16 @@ import (
 	"github.com/AshBuk/speak-to-ai/config"
 )
 
-// Defines the contract for managing the lifecycle of the fixed small-q5_1 Whisper model
+// Defines the contract for managing the lifecycle of Whisper models
 type ModelManager interface {
-	// Initialize and validate the bundled model
+	// Initialize and validate the configured model
 	Initialize() error
-	// Return the absolute path to the validated small-q5_1 model file
+	// Return the absolute path to the validated model file
 	GetModelPath() (string, error)
 	// Check if the model file at the given path is valid
 	ValidateModel(modelPath string) error
-}
-
-// Defines the contract for resolving the path to the small-q5_1 model
-type ModelPathResolver interface {
-	// Return the platform-specific path to the model file (searches multiple locations)
-	GetBundledModelPath() string
-	// Return the user data directory path for downloading the model
-	GetUserDataModelPath() string
-}
-
-// Defines the contract for downloading the whisper model
-type ModelDownloader interface {
-	// Download the model to the specified destination path
-	Download(destPath string) error
-	// Return the download URL
-	GetModelURL() string
+	// Switch to a different model by ID, downloading if needed. Returns new model path.
+	SwitchModel(modelID string) (string, error)
 }
 
 // Represents a whisper.Model type without a direct CGO dependency


### PR DESCRIPTION
Add whisper model selection (base, small, medium, large) with hot-reload.

Users can switch models at runtime via tray submenu, CLI, or IPC without restarting the daemon. 
Models download on demand from HuggingFace to ~/.local/share/speak-to-ai/models/, with thread-safe engine swapping across audio service and WebSocket server.
The previously hardcoded small-q5_1 model is now configurable and validated against a central catalog, persisted in config.yaml.