### PR TITLE
version: display on About page via centralized version package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 # Variables
 GO_VERSION := 1.24.1
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
-LDFLAGS := -s -w -X main.version=$(VERSION)
+LDFLAGS := -s -w -X github.com/AshBuk/speak-to-ai/internal/version.Version=$(VERSION)
 BINARY_NAME := speak-to-ai
 BUILD_DIR := build
 LIB_DIR := lib

--- a/cmd/speak-to-ai/daemon.go
+++ b/cmd/speak-to-ai/daemon.go
@@ -40,7 +40,6 @@ func runDaemon(args []string) int {
 	if appDir := os.Getenv("APPDIR"); appDir != "" {
 		appLogger.Info("Running inside AppImage, base path: %s", appDir)
 	}
-	configPath := opts.configFile
 	// Single-instance protection
 	lockFile := utils.NewLockFile(utils.GetDefaultLockPath())
 	if isRunning, pid, err := lockFile.CheckExistingInstance(); err != nil {
@@ -66,8 +65,7 @@ func runDaemon(args []string) int {
 	// App orchestration: delegate to App module
 	// → see internal/app/app.go
 	application := app.NewApp(appLogger)
-
-	if err := application.Initialize(configPath, opts.debug); err != nil {
+	if err := application.Initialize(opts.configFile, opts.debug); err != nil {
 		appLogger.Error("Failed to initialize application: %v", err)
 		return 1
 	}
@@ -75,7 +73,6 @@ func runDaemon(args []string) int {
 		appLogger.Error("Application error: %v", err)
 		return 1
 	}
-
 	return 0
 }
 
@@ -123,6 +120,5 @@ func parseDaemonOptions(args []string) (*daemonOptions, error) {
 		fs.Usage()
 		return nil, fmt.Errorf("unexpected arguments")
 	}
-
 	return opts, nil
 }

--- a/cmd/speak-to-ai/version.go
+++ b/cmd/speak-to-ai/version.go
@@ -7,20 +7,15 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-)
 
-// Version information - injected at build time via ldflags:
-//
-//	go build -ldflags "-X main.version=x.y.z"
-//
-// Defaults to "dev" for development builds.
-var version = "dev"
+	appversion "github.com/AshBuk/speak-to-ai/internal/version"
+)
 
 // printVersion outputs version information and exits.
 // Format: speak-to-ai version X.Y.Z (go1.XX.X linux/amd64)
 func printVersion() {
 	fmt.Printf("speak-to-ai version %s (%s %s/%s)\n",
-		version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		appversion.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 	os.Exit(0)
 }
 

--- a/internal/assets/about.html
+++ b/internal/assets/about.html
@@ -145,6 +145,7 @@
         <div class="header-text">
             <h1>Speak-to-AI</h1>
             <p>Voice-to-text Linux application with offline speech recognition</p>
+            <p style="color: #888; font-size: 0.9em; margin-top: 2px;">Version {{VERSION}}</p>
         </div>
     </div>
 

--- a/internal/services/ui_service.go
+++ b/internal/services/ui_service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/AshBuk/speak-to-ai/internal/logger"
 	"github.com/AshBuk/speak-to-ai/internal/notify"
 	"github.com/AshBuk/speak-to-ai/internal/tray"
+	appversion "github.com/AshBuk/speak-to-ai/internal/version"
 )
 
 // Coordinates tray icon states and desktop notifications
@@ -99,7 +100,8 @@ func (us *UIService) ShowAboutPage() error {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}
 	// Note: temp file for browser access
-	if _, err := tmpFile.WriteString(assets.AboutHTML); err != nil {
+	html := strings.Replace(assets.AboutHTML, "{{VERSION}}", appversion.Version, 1)
+	if _, err := tmpFile.WriteString(html); err != nil {
 		return fmt.Errorf("failed to write HTML content: %w", err)
 	}
 	if err := tmpFile.Close(); err != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,7 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
+package version
+
+// Version is set at startup by main from build-time ldflags.
+var Version = "dev"

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -53,7 +53,7 @@ build_appdir() {
 
     # Build application
     echo "Building ${APP_NAME}..."
-    go build -tags systray -ldflags "-s -w -X main.version=${APP_VERSION}" -o "${APP_NAME}" ./cmd/speak-to-ai
+    go build -tags systray -ldflags "-s -w -X github.com/AshBuk/speak-to-ai/internal/version.Version=${APP_VERSION}" -o "${APP_NAME}" ./cmd/speak-to-ai
     cp "${APP_NAME}" "${APPDIR}/usr/bin/"
     cp config.yaml "${APPDIR}/"
 

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -98,7 +98,7 @@ build() {
 
     go build -v \
         -tags systray \
-        -ldflags "-s -w -X main.version=${pkgver} -linkmode=external -extldflags '-Wl,-rpath,/usr/lib/${pkgname}'" \
+        -ldflags "-s -w -X github.com/AshBuk/speak-to-ai/internal/version.Version=${pkgver} -linkmode=external -extldflags '-Wl,-rpath,/usr/lib/${pkgname}'" \
         -o "${pkgname}" \
         ./cmd/speak-to-ai
 }

--- a/packaging/fedora/speak-to-ai.spec
+++ b/packaging/fedora/speak-to-ai.spec
@@ -171,7 +171,7 @@ VENDOR_RPATH='$ORIGIN/../lib64/%{name}'
 go build -v \
     -mod=vendor \
     -tags systray \
-    -ldflags "-s -w -X main.version=%{version} -linkmode=external -extldflags '-Wl,-rpath,${VENDOR_RPATH}'" \
+    -ldflags "-s -w -X github.com/AshBuk/speak-to-ai/internal/version.Version=%{version} -linkmode=external -extldflags '-Wl,-rpath,${VENDOR_RPATH}'" \
     -o %{name} \
     ./cmd/speak-to-ai
 


### PR DESCRIPTION
Introduce internal/version package as single source of truth for build-time version (injected via ldflags). 
About page now shows current version automatically. 
Updated all build scripts (Makefile, AppImage, RPM, Arch) to use the new package path.

Closes #78