### PR TITLE
models: rename to stt_models.go, add large-v3-turbo-q5_0

### DIFF
--- a/internal/constants/stt_models.go
+++ b/internal/constants/stt_models.go
@@ -39,6 +39,13 @@ var WhisperModels = []WhisperModelDef{
 		MinSize:  500 * 1024 * 1024, // ~539 MB
 	},
 	{
+		ID:       "large-v3-turbo-q5_0",
+		Name:     "Large v3 Turbo (Q5_0)",
+		FileName: "ggml-large-v3-turbo-q5_0.bin",
+		URL:      "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin",
+		MinSize:  500 * 1024 * 1024, // ~820 MB
+	},
+	{
 		ID:       "large-v3-q5_0",
 		Name:     "Large v3 (Q5_0)",
 		FileName: "ggml-large-v3-q5_0.bin",


### PR DESCRIPTION
Add large-v3-turbo-q5_0 Whisper model — a distilled, speed-optimized variant of Large v3 that delivers near-equivalent accuracy at significantly faster inference speed.

Excellent fit for modern laptops with capable GPUs, offering real-time transcription without sacrificing quality