### PR TITLE
Websocket/audio controller lifecycle

### DIFF
--- a/internal/notify/notification.go
+++ b/internal/notify/notification.go
@@ -76,16 +76,21 @@ func (nm *NotificationManager) sendNotification(summary, body, icon string) erro
 		return fmt.Errorf("notify-send command not allowed")
 	}
 
+	// "--" terminates option parsing so summary/body starting with "-"
+	// (e.g. an err.Error() that begins with a flag-like token) are not
+	// interpreted as notify-send options.
 	args := []string{
 		"--app-name", nm.appName,
 		"--icon", icon,
+		"--",
 		summary, body,
 	}
 
-	// Security: sanitize arguments
-	safeArgs := config.SanitizeCommandArgs(args)
-	// #nosec G204 -- Safe: notify-send is from an allowlist and arguments are sanitized
-	cmd := exec.Command("notify-send", safeArgs...)
+	// Security boundary is IsCommandAllowed above. exec.Command does not invoke a
+	// shell, so argv values are passed literally via execve and metacharacters in
+	// summary/body (e.g. error messages) are not an injection vector.
+	// #nosec G204 -- Safe: notify-send is from an allowlist; argv values are literal.
+	cmd := exec.Command("notify-send", args...)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to send notification: %w", err)
 	}

--- a/internal/services/audio_service.go
+++ b/internal/services/audio_service.go
@@ -35,6 +35,9 @@ type AudioService struct {
 	lastTranscript           string
 	audioRecorderNeedsReinit bool
 
+	// Guards whisperEngine while transcription is using it.
+	engineMu sync.RWMutex
+
 	// Goroutine ownership: tracks background transcription tasks
 	wg sync.WaitGroup
 
@@ -105,13 +108,71 @@ func (as *AudioService) HandleStartRecording() error {
 	return as.startStandardRecording()
 }
 
-// HandleStopRecording stops recording and starts transcription
+// HandleStopRecording stops recording and starts async transcription.
 func (as *AudioService) HandleStopRecording() error {
+	audioFile, err := as.stopAndPrepareTranscription(true)
+	if err != nil || audioFile == "" {
+		return err
+	}
+	select {
+	case <-as.ctx.Done():
+		as.logger.Warning("Shutdown in progress, skipping transcription")
+		return nil
+	default:
+	}
+	if as.io != nil {
+		as.io.BeginTranscription()
+	}
+	as.wg.Add(1)
+	go func() {
+		defer as.wg.Done()
+		as.transcribeAsync(audioFile)
+	}()
+	return nil
+}
+
+// HandleStopRecordingSync stops recording and returns the transcript.
+func (as *AudioService) HandleStopRecordingSync(ctx context.Context) (string, error) {
+	audioFile, err := as.stopAndPrepareTranscription(false)
+	if err != nil || audioFile == "" {
+		return "", err
+	}
+	// Always release the recorded WAV; TempFileManager would eventually do
+	// it, but eager cleanup keeps disk usage bounded under heavy API use.
+	defer as.cleanupRecording(audioFile)
+
+	select {
+	case <-as.ctx.Done():
+		return "", fmt.Errorf("shutdown in progress")
+	default:
+	}
+
+	transcript, err := as.transcribeWithCurrentEngine(ctx, audioFile)
+	if err != nil {
+		return "", err
+	}
+	sanitized := utils.SanitizeTranscript(transcript)
+	as.mu.Lock()
+	as.lastTranscript = sanitized
+	as.mu.Unlock()
+	return sanitized, nil
+}
+
+// cleanupRecording removes the captured WAV. Errors are ignored: temp
+// files are also swept by TempFileManager on a schedule.
+func (as *AudioService) cleanupRecording(audioFile string) {
+	if audioFile != "" && as.tempManager != nil {
+		as.tempManager.RemoveFile(audioFile, true)
+	}
+}
+
+// stopAndPrepareTranscription stops recording and returns the captured file.
+func (as *AudioService) stopAndPrepareTranscription(swallowStopError bool) (string, error) {
 	as.mu.Lock()
 	defer as.mu.Unlock()
 
 	if !as.isRecording {
-		return ErrNoRecordingInProgress
+		return "", ErrNoRecordingInProgress
 	}
 	as.logger.Info("Stopping recording and transcribing...")
 
@@ -122,7 +183,6 @@ func (as *AudioService) HandleStopRecording() error {
 
 		// Auto-fallback to arecord if using ffmpeg
 		if as.config.Audio.RecordingMethod == "ffmpeg" {
-			// Persist change via ConfigService if available
 			if as.cfg != nil {
 				_ = as.cfg.UpdateRecordingMethod("arecord")
 			}
@@ -130,7 +190,6 @@ func (as *AudioService) HandleStopRecording() error {
 			as.ClearSession()
 			if as.ui != nil {
 				as.ui.ShowNotification("Audio Fallback", "Switched to arecord due to ffmpeg capture error. Try recording again.")
-				// Refresh tray to reflect new method
 				as.ui.UpdateSettings(as.config)
 			}
 			as.logger.Info("Auto-fallback: switched to arecord due to ffmpeg failure")
@@ -140,33 +199,21 @@ func (as *AudioService) HandleStopRecording() error {
 		if as.ui != nil {
 			as.ui.SetRecordingState(false)
 		}
-		// Swallow error to make stop idempotent and avoid being stuck
-		return nil
+		if swallowStopError {
+			// Keep hotkey/tray stop idempotent so users can recover with the next start.
+			return "", nil
+		}
+		return "", err
 	}
 	as.isRecording = false
-	// Update UI
 	if as.ui != nil {
 		as.ui.SetRecordingState(false)
 		as.ui.ShowNotification(constants.NotifyRecordingStopped, constants.NotifyRecordingStopMsg)
 	}
-	// Check if shutdown is in progress before starting transcription
-	select {
-	case <-as.ctx.Done():
-		as.logger.Warning("Shutdown in progress, skipping transcription")
-		return nil
-	default:
+	if audioFile == "" {
+		return "", fmt.Errorf("recording produced no audio file")
 	}
-	// Signal IO that transcription is starting to protect clipboard reads
-	if as.io != nil {
-		as.io.BeginTranscription()
-	}
-	// Start async transcription with ownership tracking
-	as.wg.Add(1)
-	go func() {
-		defer as.wg.Done()
-		as.transcribeAsync(audioFile)
-	}()
-	return nil
+	return audioFile, nil
 }
 
 // IsRecording returns current recording state
@@ -183,38 +230,39 @@ func (as *AudioService) GetLastTranscript() string {
 	return as.lastTranscript
 }
 
-// SwitchModel hot-reloads the whisper engine with a different model.
-// The context allows cancellation of in-progress downloads (e.g. on app shutdown).
-// Rejects the request if recording is in progress.
+// SwitchModel hot-reloads the whisper engine.
 func (as *AudioService) SwitchModel(ctx context.Context, modelID string) error {
 	as.mu.Lock()
-	defer as.mu.Unlock()
-
 	if as.isRecording {
+		as.mu.Unlock()
 		return fmt.Errorf("cannot switch model while recording")
 	}
+	as.mu.Unlock()
 
 	newPath, err := as.modelManager.SwitchModel(ctx, modelID)
 	if err != nil {
 		return fmt.Errorf("model switch failed: %w", err)
 	}
 
-	if as.whisperEngine != nil {
-		_ = as.whisperEngine.Close()
-	}
-
 	newEngine, err := whisper.NewWhisperEngine(as.config, newPath, as.logger)
 	if err != nil {
 		return fmt.Errorf("failed to create engine for model %s: %w", modelID, err)
 	}
-	as.whisperEngine = newEngine
 
-	// Propagate engine reference to WebSocket server via IOService
-	type engineUpdater interface {
-		SetWhisperEngine(*whisper.WhisperEngine)
+	as.mu.Lock()
+	if as.isRecording {
+		as.mu.Unlock()
+		_ = newEngine.Close()
+		return fmt.Errorf("cannot switch model while recording")
 	}
-	if updater, ok := as.io.(engineUpdater); ok {
-		updater.SetWhisperEngine(newEngine)
+	as.engineMu.Lock()
+	oldEngine := as.whisperEngine
+	as.whisperEngine = newEngine
+	as.engineMu.Unlock()
+	as.mu.Unlock()
+
+	if oldEngine != nil {
+		_ = oldEngine.Close()
 	}
 	return nil
 }
@@ -333,7 +381,7 @@ func (as *AudioService) transcribeAsync(audioFile string) {
 
 	resultChan := make(chan result, 1)
 	go func() {
-		transcript, err := as.whisperEngine.TranscribeWithContext(ctx, audioFile)
+		transcript, err := as.transcribeWithCurrentEngine(ctx, audioFile)
 		select {
 		case resultChan <- result{transcript: transcript, err: err}:
 		case <-ctx.Done():
@@ -341,10 +389,23 @@ func (as *AudioService) transcribeAsync(audioFile string) {
 	}()
 	select {
 	case res := <-resultChan:
+		// Inner goroutine finished; safe to release the WAV.
+		as.cleanupRecording(audioFile)
 		as.handleTranscriptionResult(res.transcript, res.err)
 	case <-ctx.Done():
+		// Inner CGO call may still be reading the file — leave it for
+		// TempFileManager rather than risk a use-after-delete.
 		as.handleTranscriptionCancellation(ctx.Err())
 	}
+}
+
+func (as *AudioService) transcribeWithCurrentEngine(ctx context.Context, audioFile string) (string, error) {
+	as.engineMu.RLock()
+	defer as.engineMu.RUnlock()
+	if as.whisperEngine == nil {
+		return "", fmt.Errorf("whisper engine not available")
+	}
+	return as.whisperEngine.TranscribeWithContext(ctx, audioFile)
 }
 
 // handleTranscriptionResult processes transcription results

--- a/internal/services/factory_assembler.go
+++ b/internal/services/factory_assembler.go
@@ -48,6 +48,9 @@ func (sa *FactoryAssembler) Assemble(components *Components) *ServiceContainer {
 	configSvc.SetUIService(uiSvc)     // Config → UI (for reload notifications)
 	ioSvc.SetUIService(uiSvc)         // IO → UI (for output notifications)
 	ioSvc.SetConfigService(configSvc) // IO → Config (for output settings)
+	if components.WebSocketServer != nil {
+		components.WebSocketServer.SetAudioController(audioSvc)
+	}
 
 	// Step 3: Pack services into container
 	container.Config = configSvc

--- a/internal/services/factory_components.go
+++ b/internal/services/factory_components.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/AshBuk/speak-to-ai/audio/factory"
-	"github.com/AshBuk/speak-to-ai/audio/interfaces"
 	"github.com/AshBuk/speak-to-ai/audio/processing"
 	"github.com/AshBuk/speak-to-ai/config"
 	"github.com/AshBuk/speak-to-ai/hotkeys/adapters"
@@ -89,8 +88,9 @@ func (cf *FactoryComponents) InitializeComponents() (*Components, error) {
 	}
 	// Initialize hotkey manager
 	components.HotkeyManager = cf.createHotkeyManager()
-	// Initialize WebSocket server (always initialized but may not be started)
-	components.WebSocketServer = cf.createWebSocketServer(components.Recorder, components.WhisperEngine)
+	// Initialize WebSocket server (always initialized but may not be started).
+	// AudioController is wired in Stage 2 by FactoryAssembler once AudioService exists.
+	components.WebSocketServer = cf.createWebSocketServer()
 	// Initialize tray manager
 	components.TrayManager = cf.createTrayManager()
 	// Start tray manager (no-op in mock). Ensures systray is initialized early.
@@ -178,8 +178,8 @@ func (cf *FactoryComponents) createHotkeyManager() *manager.HotkeyManager {
 }
 
 // createWebSocketServer creates WebSocket server
-func (cf *FactoryComponents) createWebSocketServer(recorder interfaces.AudioRecorder, whisperEngine *whisper.WhisperEngine) *websocket.WebSocketServer {
-	return websocket.NewWebSocketServer(cf.config.Config, recorder, whisperEngine, cf.config.Logger)
+func (cf *FactoryComponents) createWebSocketServer() *websocket.WebSocketServer {
+	return websocket.NewWebSocketServer(cf.config.Config, cf.config.Logger)
 }
 
 // createTrayManager creates system tray manager.

--- a/internal/services/io_service.go
+++ b/internal/services/io_service.go
@@ -14,7 +14,6 @@ import (
 	outputFactory "github.com/AshBuk/speak-to-ai/output/factory"
 	outputInterfaces "github.com/AshBuk/speak-to-ai/output/interfaces"
 	"github.com/AshBuk/speak-to-ai/websocket"
-	"github.com/AshBuk/speak-to-ai/whisper"
 )
 
 // Handles text output routing and transcription synchronization
@@ -231,13 +230,6 @@ func (ios *IOService) detectOutputEnvironment() outputFactory.EnvironmentType {
 		return outputFactory.EnvironmentX11
 	default:
 		return outputFactory.EnvironmentUnknown
-	}
-}
-
-// SetWhisperEngine updates the WebSocket server's whisper engine reference after hot-reload
-func (ios *IOService) SetWhisperEngine(engine *whisper.WhisperEngine) {
-	if ios.webSocketServer != nil {
-		ios.webSocketServer.SetWhisperEngine(engine)
 	}
 }
 

--- a/output/outputters/type_outputter.go
+++ b/output/outputters/type_outputter.go
@@ -43,30 +43,30 @@ func (o *TypeOutputter) TypeToActiveWindow(text string) error {
 	var cmd *exec.Cmd
 	var args []string
 
+	// Use "--" to terminate option parsing where supported, so a transcript
+	// that happens to start with "-"/"--" is not interpreted as a flag.
 	switch o.typeTool {
 	case "xdotool":
-		args = []string{"type", "--clearmodifiers", text}
+		args = []string{"type", "--clearmodifiers", "--", text}
 	case "wtype":
-		args = []string{text}
+		args = []string{"--", text}
 	case "ydotool":
+		// ydotool's option parser does not document "--", pass text directly.
 		args = []string{"type", text}
 	default:
 		return fmt.Errorf("unsupported typing tool: %s", o.typeTool)
 	}
 
-	// Security: sanitize arguments
-	safeArgs := config.SanitizeCommandArgs(args)
-	// #nosec G204 -- Safe: tool is from an allowlist and arguments are sanitized
-	cmd = exec.Command(o.typeTool, safeArgs...)
+	// #nosec G204 -- Tool is allowlisted; text is passed as argv, not shell input.
+	cmd = exec.Command(o.typeTool, args...)
 	// Run the command
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		// Runtime fallback: if wtype fails, try ydotool if it is allowed and available
 		if o.typeTool == "wtype" && config.IsCommandAllowed(o.config, "ydotool") {
 			if _, lookErr := exec.LookPath("ydotool"); lookErr == nil {
-				fallbackArgs := config.SanitizeCommandArgs([]string{"type", text})
-				// #nosec G204 -- Safe: tool is from an allowlist and arguments are sanitized
-				fallbackCmd := exec.Command("ydotool", fallbackArgs...)
+				// #nosec G204 -- Tool is allowlisted; text is passed as argv, not shell input.
+				fallbackCmd := exec.Command("ydotool", "type", text)
 				if fbOut, fbErr := fallbackCmd.CombinedOutput(); fbErr == nil {
 					return nil
 				} else {

--- a/output/outputters/type_outputter_test.go
+++ b/output/outputters/type_outputter_test.go
@@ -4,7 +4,10 @@
 package outputters
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/AshBuk/speak-to-ai/config"
@@ -125,19 +128,28 @@ func TestTypeOutputter_TypeToActiveWindow_SupportedTools(t *testing.T) {
 		{
 			name: "xdotool",
 			tool: "xdotool",
+			expectedArgs: []string{
+				"type",
+				"--clearmodifiers",
+				"--",
+				"test text",
+			},
 		},
 		{
-			name: "wtype",
-			tool: "wtype",
+			name:         "wtype",
+			tool:         "wtype",
+			expectedArgs: []string{"--", "test text"},
 		},
 		{
-			name: "ydotool",
-			tool: "ydotool",
+			name:         "ydotool",
+			tool:         "ydotool",
+			expectedArgs: []string{"type", "test text"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			captureFile := installFakeTool(t, tt.tool)
 			cfg := &config.Config{}
 			cfg.Security.AllowedCommands = []string{tt.tool}
 
@@ -146,19 +158,42 @@ func TestTypeOutputter_TypeToActiveWindow_SupportedTools(t *testing.T) {
 				config:   cfg,
 			}
 
-			// This will fail since the tools don't exist, but we're testing the command building logic
 			err := outputter.TypeToActiveWindow("test text")
-
-			// We expect an error since the tools don't exist, but it should be a "failed to type" error
-			// not an "unsupported tool" error
 			if err == nil {
-				t.Error("expected error since tool doesn't exist")
+				args := readCapturedArgs(t, captureFile)
+				if strings.Join(args, "\n") != strings.Join(tt.expectedArgs, "\n") {
+					t.Fatalf("expected args %q, got %q", tt.expectedArgs, args)
+				}
+				return
 			}
-			if err != nil && err.Error() == "unsupported typing tool: "+tt.tool {
-				t.Errorf("tool %s should be supported", tt.tool)
-			}
+			t.Fatalf("expected fake %s to run successfully, got %v", tt.tool, err)
 		})
 	}
+}
+
+func installFakeTool(t *testing.T, tool string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	captureFile := filepath.Join(dir, "args.txt")
+	script := filepath.Join(dir, tool)
+	content := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$CAPTURE_FILE\"\n"
+	if err := os.WriteFile(script, []byte(content), 0700); err != nil {
+		t.Fatalf("write fake tool: %v", err)
+	}
+	t.Setenv("PATH", dir)
+	t.Setenv("CAPTURE_FILE", captureFile)
+	return captureFile
+}
+
+func readCapturedArgs(t *testing.T, path string) []string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	return strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
 }
 
 func TestTypeOutputter_CopyToClipboard(t *testing.T) {
@@ -179,12 +214,6 @@ func TestTypeOutputter_CopyToClipboard(t *testing.T) {
 }
 
 func TestTypeOutputter_Interface(t *testing.T) {
-	cfg := &config.Config{}
-	outputter := &TypeOutputter{
-		typeTool: "xdotool",
-		config:   cfg,
-	}
-
 	// Verify it implements the interfaces.Outputter interface
-	var _ interfaces.Outputter = outputter
+	var _ interfaces.Outputter = (*TypeOutputter)(nil)
 }

--- a/websocket/message_handler.go
+++ b/websocket/message_handler.go
@@ -50,13 +50,14 @@ func (s *WebSocketServer) processMessages(conn *websocket.Conn) {
 	}
 }
 
-// Initiate recording session with retry logic for reliability
+// Start recording through AudioService.
 func (s *WebSocketServer) handleStartRecording(conn *websocket.Conn, requestID string) {
-	// Start recording
-	err := s.executeWithRetry(func() error {
-		return s.recorder.StartRecording()
-	}, conn)
-
+	audio := s.audioController()
+	if audio == nil {
+		s.sendError(conn, "recording_error", "audio controller not wired", requestID)
+		return
+	}
+	err := s.executeWithRetry(audio.HandleStartRecording, conn)
 	if err != nil {
 		s.logger.Error("Error starting recording: %v", err)
 		s.sendError(conn, "recording_error", fmt.Sprintf("Error starting recording: %v", err), requestID)
@@ -65,52 +66,32 @@ func (s *WebSocketServer) handleStartRecording(conn *websocket.Conn, requestID s
 	s.sendMessage(conn, "recording-started", nil, requestID)
 }
 
-// Complete recording workflow and deliver transcription result
+// Stop recording through AudioService and return the transcript.
 func (s *WebSocketServer) handleStopRecording(conn *websocket.Conn, requestID string) {
-	// Stop recording
-	audioFile, err := s.recorder.StopRecording()
-	if err != nil {
-		s.logger.Error("Error stopping recording: %v", err)
-		s.sendError(conn, "recording_error", fmt.Sprintf("Error stopping recording: %v", err), requestID)
+	audio := s.audioController()
+	if audio == nil {
+		s.sendError(conn, "recording_error", "audio controller not wired", requestID)
 		return
 	}
-	// Notify client that recording has stopped
-	s.sendMessage(conn, "recording-stopped", nil, requestID)
-	// Send the audio file to Whisper for transcription
-	type transcriptionResult struct {
-		text string
-		err  error
-	}
-	// Create channel for receiving transcription result
-	resultCh := make(chan transcriptionResult, 1)
-	// Start transcription in a goroutine with timeout context
+
 	ctx, cancel := context.WithTimeout(context.Background(), transcriptionCtxTimeout)
 	defer cancel()
-	go func() {
-		text, err := s.whisperEngine().TranscribeWithContext(ctx, audioFile)
-		resultCh <- transcriptionResult{text: text, err: err}
-	}()
-
-	// Wait for result with timeout
-	select {
-	case result := <-resultCh:
-		if result.err != nil {
-			s.logger.Error("Error transcribing audio: %v", result.err)
-			s.sendError(conn, "transcription_error", fmt.Sprintf("Error transcribing audio: %v", result.err), requestID)
-		} else {
-			// Success - send transcribed text
-			s.sendMessage(conn, "transcription", map[string]string{
-				"text": result.text,
-			}, requestID)
+	text, err := audio.HandleStopRecordingSync(ctx)
+	if err != nil {
+		if ctx.Err() != nil {
+			s.logger.Error("Timeout transcribing audio")
+			s.sendError(conn, "transcription_timeout", "Timeout transcribing audio", requestID)
+			return
 		}
-	case <-time.After(transcriptionTimeout):
-		s.logger.Error("Timeout transcribing audio")
-		s.sendError(conn, "transcription_timeout", "Timeout transcribing audio", requestID)
+		s.logger.Error("Error stopping/transcribing: %v", err)
+		s.sendError(conn, "transcription_error", fmt.Sprintf("Error transcribing audio: %v", err), requestID)
+		return
 	}
-	// Clean up audio file
-	if err := s.recorder.CleanupFile(); err != nil {
-		s.logger.Error("Error cleaning up audio file: %v", err)
-	}
+	// Confirm stop after the operation actually succeeded, then deliver
+	s.sendMessage(conn, "recording-stopped", nil, requestID)
+	s.sendMessage(conn, "transcription", map[string]string{
+		"text": text,
+	}, requestID)
 }
 
 // Deliver structured error response for client debugging

--- a/websocket/retry_manager.go
+++ b/websocket/retry_manager.go
@@ -24,9 +24,7 @@ func (s *WebSocketServer) executeWithRetry(fn func() error, conn *websocket.Conn
 
 	// If successful or reached max retries, reset counter and return
 	if err == nil || currentRetries >= maxRetries {
-		s.clientsLock.Lock()
-		s.retryCount[conn] = 0
-		s.clientsLock.Unlock()
+		s.resetRetryCount(conn)
 		return err
 	}
 
@@ -44,7 +42,7 @@ func (s *WebSocketServer) executeWithRetry(fn func() error, conn *websocket.Conn
 }
 
 // Clear retry state after successful operation or cleanup
-func (s *WebSocketServer) resetRetryCount(conn *websocket.Conn) { // nolint:unused // used in defer cleanup
+func (s *WebSocketServer) resetRetryCount(conn *websocket.Conn) {
 	s.clientsLock.Lock()
 	defer s.clientsLock.Unlock()
 	s.retryCount[conn] = 0

--- a/websocket/server.go
+++ b/websocket/server.go
@@ -11,12 +11,16 @@ import (
 	"sync"
 	"time"
 
-	"github.com/AshBuk/speak-to-ai/audio/interfaces"
 	"github.com/AshBuk/speak-to-ai/config"
 	"github.com/AshBuk/speak-to-ai/internal/logger"
-	"github.com/AshBuk/speak-to-ai/whisper"
 	"github.com/gorilla/websocket"
 )
+
+// AudioController exposes recording actions to WebSocket handlers.
+type AudioController interface {
+	HandleStartRecording() error
+	HandleStopRecordingSync(ctx context.Context) (string, error)
+}
 
 // WebSocket server configuration constants
 const (
@@ -35,7 +39,6 @@ const (
 	serverWriteTimeout      = 15 * time.Second // HTTP server write timeout
 	serverIdleTimeout       = 60 * time.Second // HTTP server idle timeout
 	shutdownTimeout         = 5 * time.Second  // Graceful shutdown timeout
-	transcriptionTimeout    = 30 * time.Second // Whisper transcription timeout
 	transcriptionCtxTimeout = 30 * time.Second // Context timeout for transcription
 )
 
@@ -45,9 +48,8 @@ type WebSocketServer struct {
 	clients     map[*websocket.Conn]bool
 	clientsLock sync.Mutex
 	upgrader    websocket.Upgrader
-	recorder    interfaces.AudioRecorder
-	whisper     *whisper.WhisperEngine
-	whisperLock sync.RWMutex
+	audio       AudioController
+	audioMu     sync.RWMutex
 	server      *http.Server
 	started     bool
 	retryCount  map[*websocket.Conn]int // Track retry attempts
@@ -86,8 +88,8 @@ func checkOriginFunc(cfg *config.Config) func(*http.Request) bool {
 	}
 }
 
-// Initialize server with security and resource constraints
-func NewWebSocketServer(config *config.Config, recorder interfaces.AudioRecorder, whisperEngine *whisper.WhisperEngine, logger logger.Logger) *WebSocketServer {
+// Initialize server with security and resource constraints.
+func NewWebSocketServer(config *config.Config, logger logger.Logger) *WebSocketServer {
 	return &WebSocketServer{
 		config:  config,
 		clients: make(map[*websocket.Conn]bool),
@@ -96,25 +98,23 @@ func NewWebSocketServer(config *config.Config, recorder interfaces.AudioRecorder
 			WriteBufferSize: writeBufferSize,
 			CheckOrigin:     checkOriginFunc(config),
 		},
-		recorder:   recorder,
-		whisper:    whisperEngine,
 		retryCount: make(map[*websocket.Conn]int),
 		logger:     logger,
 	}
 }
 
-// SetWhisperEngine replaces the whisper engine reference (used after model hot-reload)
-func (s *WebSocketServer) SetWhisperEngine(engine *whisper.WhisperEngine) {
-	s.whisperLock.Lock()
-	s.whisper = engine
-	s.whisperLock.Unlock()
+// SetAudioController wires recording actions.
+func (s *WebSocketServer) SetAudioController(audio AudioController) {
+	s.audioMu.Lock()
+	s.audio = audio
+	s.audioMu.Unlock()
 }
 
-// whisperEngine returns the current whisper engine (thread-safe)
-func (s *WebSocketServer) whisperEngine() *whisper.WhisperEngine {
-	s.whisperLock.RLock()
-	defer s.whisperLock.RUnlock()
-	return s.whisper
+// audioController returns the current AudioController (thread-safe).
+func (s *WebSocketServer) audioController() AudioController {
+	s.audioMu.RLock()
+	defer s.audioMu.RUnlock()
+	return s.audio
 }
 
 // Begin accepting client connections with health monitoring

--- a/websocket/server_test.go
+++ b/websocket/server_test.go
@@ -4,6 +4,7 @@
 package websocket
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -12,21 +13,28 @@ import (
 	"testing"
 	"time"
 
-	"github.com/AshBuk/speak-to-ai/audio/mocks"
 	"github.com/AshBuk/speak-to-ai/config"
 	"github.com/AshBuk/speak-to-ai/internal/testutils"
-	"github.com/AshBuk/speak-to-ai/whisper"
 	"github.com/gorilla/websocket"
 )
 
 // Mock implementations for testing
-type MockWhisperEngine struct {
-	transcribeResult string
-	transcribeErr    error
+type mockAudioController struct {
+	startErr   error
+	stopText   string
+	stopErr    error
+	startCalls int
+	stopCalls  int
 }
 
-func (m *MockWhisperEngine) Transcribe(audioFile string) (string, error) {
-	return m.transcribeResult, m.transcribeErr
+func (m *mockAudioController) HandleStartRecording() error {
+	m.startCalls++
+	return m.startErr
+}
+
+func (m *mockAudioController) HandleStopRecordingSync(_ context.Context) (string, error) {
+	m.stopCalls++
+	return m.stopText, m.stopErr
 }
 
 func createTestConfig() *config.Config {
@@ -43,18 +51,11 @@ func createTestConfig() *config.Config {
 	return cfg
 }
 
-func createTestWhisperEngine(cfg *config.Config) *whisper.WhisperEngine {
-	engine, _ := whisper.NewWhisperEngine(cfg, "/dev/null")
-	return engine
-}
-
 func TestNewWebSocketServer(t *testing.T) {
 	cfg := createTestConfig()
-	recorder := &mocks.MockAudioRecorder{}
-	whisperEngine, _ := whisper.NewWhisperEngine(cfg, "/dev/null")
 	logger := testutils.NewMockLogger()
 
-	server := NewWebSocketServer(cfg, recorder, whisperEngine, logger)
+	server := NewWebSocketServer(cfg, logger)
 	if server == nil {
 		t.Fatal("NewWebSocketServer returned nil")
 	}
@@ -80,7 +81,7 @@ func TestWebSocketServer_Start_Disabled(t *testing.T) {
 	cfg := createTestConfig()
 	cfg.WebServer.Enabled = false
 
-	server := NewWebSocketServer(cfg, &mocks.MockAudioRecorder{}, createTestWhisperEngine(cfg), testutils.NewMockLogger())
+	server := NewWebSocketServer(cfg, testutils.NewMockLogger())
 
 	err := server.Start()
 
@@ -97,7 +98,7 @@ func TestWebSocketServer_Start_Enabled(t *testing.T) {
 	cfg := createTestConfig()
 	cfg.WebServer.Port = 0 // Use random port for testing
 
-	server := NewWebSocketServer(cfg, &mocks.MockAudioRecorder{}, createTestWhisperEngine(cfg), testutils.NewMockLogger())
+	server := NewWebSocketServer(cfg, testutils.NewMockLogger())
 	err := server.Start()
 	if err != nil {
 		t.Errorf("Expected no error when starting server, got %v", err)
@@ -112,7 +113,7 @@ func TestWebSocketServer_Stop(t *testing.T) {
 	cfg := createTestConfig()
 	cfg.WebServer.Port = 0 // Use random port for testing
 
-	server := NewWebSocketServer(cfg, &mocks.MockAudioRecorder{}, createTestWhisperEngine(cfg), testutils.NewMockLogger())
+	server := NewWebSocketServer(cfg, testutils.NewMockLogger())
 	// Start server
 	err := server.Start()
 	if err != nil {
@@ -133,7 +134,7 @@ func TestWebSocketServer_Authentication_NoToken(t *testing.T) {
 	cfg := createTestConfig()
 	cfg.WebServer.AuthToken = ""
 
-	server := NewWebSocketServer(cfg, &mocks.MockAudioRecorder{}, createTestWhisperEngine(cfg), testutils.NewMockLogger())
+	server := NewWebSocketServer(cfg, testutils.NewMockLogger())
 	// Create test request
 	req := httptest.NewRequest("GET", "/ws", nil)
 	result := server.authenticate(req)
@@ -146,7 +147,7 @@ func TestWebSocketServer_Authentication_WithToken(t *testing.T) {
 	cfg := createTestConfig()
 	cfg.WebServer.AuthToken = "test-token"
 
-	server := NewWebSocketServer(cfg, &mocks.MockAudioRecorder{}, createTestWhisperEngine(cfg), testutils.NewMockLogger())
+	server := NewWebSocketServer(cfg, testutils.NewMockLogger())
 
 	tests := []struct {
 		name       string
@@ -205,7 +206,7 @@ func TestWebSocketServer_ValidateToken(t *testing.T) {
 	cfg := createTestConfig()
 	cfg.WebServer.AuthToken = "test-token"
 
-	server := NewWebSocketServer(cfg, &mocks.MockAudioRecorder{}, createTestWhisperEngine(cfg), testutils.NewMockLogger())
+	server := NewWebSocketServer(cfg, testutils.NewMockLogger())
 
 	tests := []struct {
 		name     string
@@ -248,7 +249,7 @@ func TestWebSocketServer_ValidateToken_NoAuthToken(t *testing.T) {
 	cfg := createTestConfig()
 	cfg.WebServer.AuthToken = ""
 
-	server := NewWebSocketServer(cfg, &mocks.MockAudioRecorder{}, createTestWhisperEngine(cfg), testutils.NewMockLogger())
+	server := NewWebSocketServer(cfg, testutils.NewMockLogger())
 
 	result := server.validateToken("any-token")
 
@@ -259,7 +260,7 @@ func TestWebSocketServer_ValidateToken_NoAuthToken(t *testing.T) {
 
 func TestWebSocketServer_SendMessage(t *testing.T) {
 	cfg := createTestConfig()
-	server := NewWebSocketServer(cfg, &mocks.MockAudioRecorder{}, createTestWhisperEngine(cfg), testutils.NewMockLogger())
+	server := NewWebSocketServer(cfg, testutils.NewMockLogger())
 
 	// Create test WebSocket connection
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -311,9 +312,98 @@ func TestWebSocketServer_SendMessage(t *testing.T) {
 	}
 }
 
+func TestWebSocketServer_HandleStartRecordingSendsStarted(t *testing.T) {
+	server := NewWebSocketServer(createTestConfig(), testutils.NewMockLogger())
+	audio := &mockAudioController{}
+	server.SetAudioController(audio)
+
+	messages := collectHandlerMessages(t, server, 1, func(conn *websocket.Conn) {
+		server.handleStartRecording(conn, "req-start")
+	})
+
+	if audio.startCalls != 1 {
+		t.Fatalf("expected one start call, got %d", audio.startCalls)
+	}
+	if messages[0].Type != "recording-started" || messages[0].RequestID != "req-start" {
+		t.Fatalf("unexpected start message: %+v", messages[0])
+	}
+}
+
+func TestWebSocketServer_HandleStopRecordingSendsStoppedThenTranscription(t *testing.T) {
+	server := NewWebSocketServer(createTestConfig(), testutils.NewMockLogger())
+	audio := &mockAudioController{stopText: "hello"}
+	server.SetAudioController(audio)
+
+	messages := collectHandlerMessages(t, server, 2, func(conn *websocket.Conn) {
+		server.handleStopRecording(conn, "req-stop")
+	})
+
+	if audio.stopCalls != 1 {
+		t.Fatalf("expected one stop call, got %d", audio.stopCalls)
+	}
+	if messages[0].Type != "recording-stopped" || messages[0].RequestID != "req-stop" {
+		t.Fatalf("unexpected stop message: %+v", messages[0])
+	}
+	payload, ok := messages[1].Payload.(map[string]interface{})
+	if !ok || messages[1].Type != "transcription" || payload["text"] != "hello" {
+		t.Fatalf("unexpected transcription message: %+v", messages[1])
+	}
+}
+
+func TestWebSocketServer_HandleStopRecordingErrorDoesNotSendStopped(t *testing.T) {
+	server := NewWebSocketServer(createTestConfig(), testutils.NewMockLogger())
+	server.SetAudioController(&mockAudioController{stopErr: fmt.Errorf("stop failed")})
+
+	messages := collectHandlerMessages(t, server, 1, func(conn *websocket.Conn) {
+		server.handleStopRecording(conn, "req-stop")
+	})
+
+	if messages[0].Type != "error" || messages[0].Error != "transcription_error" {
+		t.Fatalf("unexpected stop error message: %+v", messages[0])
+	}
+}
+
+func collectHandlerMessages(t *testing.T, server *WebSocketServer, count int, action func(*websocket.Conn)) []Message {
+	t.Helper()
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := server.upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade connection: %v", err)
+			return
+		}
+		defer conn.Close()
+		action(conn)
+	}))
+	defer testServer.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(testServer.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer conn.Close()
+
+	messages := make([]Message, 0, count)
+	for len(messages) < count {
+		if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+			t.Fatalf("set read deadline: %v", err)
+		}
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("read message %d/%d: %v", len(messages)+1, count, err)
+		}
+		var msg Message
+		if err := json.Unmarshal(data, &msg); err != nil {
+			t.Fatalf("unmarshal message: %v", err)
+		}
+		messages = append(messages, msg)
+	}
+	return messages
+}
+
 func TestWebSocketServer_ExecuteWithRetry_Success(t *testing.T) {
 	cfg := createTestConfig()
-	server := NewWebSocketServer(cfg, &mocks.MockAudioRecorder{}, createTestWhisperEngine(cfg), testutils.NewMockLogger())
+	server := NewWebSocketServer(cfg, testutils.NewMockLogger())
 
 	// Create mock connection
 	conn := &websocket.Conn{}
@@ -345,7 +435,7 @@ func TestWebSocketServer_ExecuteWithRetry_Success(t *testing.T) {
 
 func TestWebSocketServer_ExecuteWithRetry_MaxRetries(t *testing.T) {
 	cfg := createTestConfig()
-	server := NewWebSocketServer(cfg, &mocks.MockAudioRecorder{}, createTestWhisperEngine(cfg), testutils.NewMockLogger())
+	server := NewWebSocketServer(cfg, testutils.NewMockLogger())
 
 	// Create mock connection
 	conn := &websocket.Conn{}

--- a/whisper/engine.go
+++ b/whisper/engine.go
@@ -127,33 +127,25 @@ func (w *WhisperEngine) Transcribe(audioFile string) (string, error) {
 	return result, nil
 }
 
-// TranscribeWithContext performs speech-to-text conversion with timeout support.
-//
-// IMPORTANT: This method provides early return on context cancellation, but the
-// underlying whisper.cpp transcription cannot be interrupted. The internal goroutine
-// will continue running until completion. This is acceptable because:
-// 1. Transcription is bounded by audio file size (max 50MB, typically < 30s processing)
-// 2. The caller (AudioService) owns the lifecycle via WaitGroup and waits on shutdown
-// 3. Only one transcription runs at a time (enforced by AudioService.isRecording mutex)
-//
-// For true cancellation support, whisper.cpp would need upstream changes.
+// TranscribeWithContext performs speech-to-text conversion.
+// whisper.cpp processing cannot be interrupted safely, so context cancellation is
+// checked before and after the synchronous call instead of spawning hidden work.
 func (w *WhisperEngine) TranscribeWithContext(ctx context.Context, audioFile string) (string, error) {
-	type result struct {
-		text string
-		err  error
-	}
-	ch := make(chan result, 1)
-
-	go func() {
-		txt, err := w.Transcribe(audioFile)
-		ch <- result{text: txt, err: err}
-	}()
-
 	select {
-	case r := <-ch:
-		return r.text, r.err
 	case <-ctx.Done():
 		return "", fmt.Errorf("transcription cancelled: %w", ctx.Err())
+	default:
+	}
+
+	txt, err := w.Transcribe(audioFile)
+	if err != nil {
+		return "", err
+	}
+	select {
+	case <-ctx.Done():
+		return "", fmt.Errorf("transcription cancelled: %w", ctx.Err())
+	default:
+		return txt, nil
 	}
 }
 


### PR DESCRIPTION
Route WebSocket recording through AudioService instead of holding direct recorder/WhisperEngine references, so WebSocket, tray, hotkeys, and model hot-reload share the same lifecycle. It also fixes transcription cancellation/resource ownership so audio files and Whisper models are not cleaned up while native processing is still active.

Additionally, desktop notification and typing commands now pass user text as literal argv values, preserving transcripts that begin with option-like text.