### PR TITLE
Security/hotkeys least privilege

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,26 +76,18 @@ Download the latest AppImage from [Releases](https://github.com/AshBuk/dabri/rel
 ```bash
 # Download the file, then:
 chmod +x dabri-*.AppImage
-# Ensure user is in input group for hotkeys to work:
-sudo usermod -a -G input $USER
-# then logout/login or reboot
-# Open via GUI or with terminal command:
 ./dabri-*.AppImage
 ```
 
 ### Arch Linux [AUR](https://aur.archlinux.org/packages/dabri):
 ```bash
 yay -S dabri
-# Ensure user is in input group:
-sudo usermod -a -G input $USER
 ```
 
 ### Fedora [COPR](https://copr.fedorainfracloud.org/coprs/ashbuk/dabri/):
 ```bash
 sudo dnf copr enable ashbuk/dabri
 sudo dnf install dabri
-# Ensure user is in input group:
-sudo usermod -a -G input $USER
 ```
 
 ## Desktop Environment Compatibility

--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,9 @@ general:
 
 # Hotkey settings
 hotkeys:
+  # provider: "evdev"  # Uncomment to use evdev (direct input access) instead of D-Bus portal.
+  #                    # Requires udev rule or input group — see docs/Desktop_Environment_Support.md.
+  #                    # Default (omitted): dbus → evdev → disabled.
   start_recording: "alt+r"            # Start/stop recording
   stop_recording: "alt+r"             # Same combination for start/stop
   show_config: "alt+c"                # Open configuration file

--- a/config/models/config.go
+++ b/config/models/config.go
@@ -21,7 +21,8 @@ type Config struct {
 	} `yaml:"general"`
 
 	Hotkeys struct {
-		// Hotkey provider override. Use "auto" for automatic detection, or force a specific backend like "dbus" or "evdev"
+		// Hotkey provider: "dbus" (default, portal-based) | "evdev" (direct input, requires udev rule or input group).
+		// Omit or leave empty for auto-selection: dbus → evdev → disabled.
 		Provider        string `yaml:"provider"`
 		StartRecording  string `yaml:"start_recording"`
 		StopRecording   string `yaml:"stop_recording"`

--- a/docker/Dockerfile.appimage
+++ b/docker/Dockerfile.appimage
@@ -11,7 +11,6 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     git \
     curl \
-    wget \
     libayatana-appindicator3-dev \
     libgtk-3-dev \
     libglib2.0-dev \
@@ -62,11 +61,6 @@ COPY . .
 # Create necessary directories
 RUN mkdir -p lib sources build dist
 
-# Build script and template for AppImage
-COPY packaging/appimage/build-appimage.sh /usr/local/bin/build-appimage.sh
-COPY packaging/appimage/AppRun /usr/local/bin/AppRun
-RUN chmod +x /usr/local/bin/build-appimage.sh /usr/local/bin/AppRun
-
 # Set environment variables for CGO
 ENV CGO_ENABLED=1
 ENV C_INCLUDE_PATH="/app/lib"
@@ -85,7 +79,7 @@ ARG WHISPER_CPP_REF=v1.8.4
 ENV WHISPER_CPP_REF=${WHISPER_CPP_REF}
 
 # Build AppImage at image build time so docker build can produce artifacts
-RUN /usr/local/bin/build-appimage.sh
+RUN packaging/appimage/build-appimage.sh
 
 # Export artifacts stage
 FROM scratch AS artifacts

--- a/docs/Desktop_Environment_Support.md
+++ b/docs/Desktop_Environment_Support.md
@@ -83,7 +83,20 @@ systemctl --user enable --now ydotool
 
 ## ⌨️ **Hotkeys**
 
-By default, Dabri uses the **D-Bus GlobalShortcuts portal** — the Wayland-native sandboxed approach. No setup required on GNOME and KDE. Rebind via *Settings → Keyboard Shortcuts*.
+By default, Dabri uses the **D-Bus GlobalShortcuts portal** — the Wayland-native sandboxed approach. No setup required on GNOME and KDE.
+
+**Edit config directly** — open `~/.config/dabri/config.yaml` and set your key combination:
+```yaml
+hotkeys:
+  start_recording: "ctrl+shift+r"
+  stop_recording: "ctrl+shift+r"
+```
+Restart Dabri after saving.
+
+**Or add a custom shortcut:**
+**GNOME:** *Settings → Keyboard → Keyboard Shortcuts → Custom Shortcuts → `+`* → command: `dabri toggle`
+
+**KDE:** Add a custom shortcut: *System Settings → Shortcuts → Custom Shortcuts → `+`* → command: `dabri toggle`
 
 **Hyprland:** The portal registers shortcuts, but Hyprland requires explicit binding in `hyprland.conf`. Run `hyprctl globalshortcuts` while Dabri is running to see the registered IDs, then add:
 ```

--- a/docs/Desktop_Environment_Support.md
+++ b/docs/Desktop_Environment_Support.md
@@ -81,15 +81,35 @@ systemctl --user enable --now ydotool
 - Requires manual `Ctrl+V` after speech recognition
 - No additional setup needed
 
-## ⌨️ **Hotkey Support Status (for hotkey registration and binding)**
+## ⌨️ **Hotkeys**
 
-### **All Packages (native & AppImage)**
-- **All DEs:** **evdev first (requires input group)** → D-Bus GlobalShortcuts portal fallback. **evdev** enables native hotkey capture and binding via system tray menu
-- **Fallback:** If evdev unavailable, attempts D-Bus GlobalShortcuts portal
-- **Setup input group:**
+By default, Dabri uses the **D-Bus GlobalShortcuts portal** — the Wayland-native sandboxed approach. No setup required on GNOME and KDE. Rebind via *Settings → Keyboard Shortcuts*.
+
+### **Optional: evdev**
+
+The classic X11-era approach — direct raw input access. Opt in if:
+- Your WM/DE doesn't implement XDG GlobalShortcuts (i3, bspwm, openbox, etc.)
+- You want to rebind hotkeys from the **Dabri tray menu** directly
+- Portal behavior is inconsistent on your setup
+
+**Trade-off:** requires access to all input devices (`/dev/input/event*`), not just keyboard.
+
+**Option A — udev rule (scoped to session user):**
 ```bash
-sudo usermod -a -G input $USER
-# Log out and log back in for changes to take effect
+echo 'KERNEL=="event*", SUBSYSTEM=="input", ATTRS{capabilities/key}!="0", TAG+="uaccess"' \
+  | sudo tee /etc/udev/rules.d/70-dabri-input.rules
+sudo udevadm control --reload && sudo udevadm trigger
+```
+
+**Option B — input group (broader access):**
+```bash
+sudo usermod -a -G input $USER  # then logout/login
+```
+
+Then enable in `~/.config/dabri/config.yaml`:
+```yaml
+hotkeys:
+  provider: evdev
 ```
 
 ### **Direct Hotkey Binding via DE/WM**

--- a/docs/Desktop_Environment_Support.md
+++ b/docs/Desktop_Environment_Support.md
@@ -85,9 +85,14 @@ systemctl --user enable --now ydotool
 
 By default, Dabri uses the **D-Bus GlobalShortcuts portal** — the Wayland-native sandboxed approach. No setup required on GNOME and KDE. Rebind via *Settings → Keyboard Shortcuts*.
 
+**Hyprland:** The portal registers shortcuts, but Hyprland requires explicit binding in `hyprland.conf`. Run `hyprctl globalshortcuts` while Dabri is running to see the registered IDs, then add:
+```
+bind = <mods>, <key>, global, <appid>:<shortcutid>
+```
+
 ### **Optional: evdev**
 
-The classic X11-era approach — direct raw input access. Opt in if:
+The classic X11 approach — direct raw input access. Opt in if:
 - Your WM/DE doesn't implement XDG GlobalShortcuts (i3, bspwm, openbox, etc.)
 - You want to rebind hotkeys from the **Dabri tray menu** directly
 - Portal behavior is inconsistent on your setup
@@ -147,4 +152,4 @@ Add to `~/.config/hypr/hyprland.conf`:
 exec-once = dabri
 ```
 
-*Last updated: 2026-05-19*
+*Last updated: 2026-05-21*

--- a/hotkeys/manager/manager_linux.go
+++ b/hotkeys/manager/manager_linux.go
@@ -19,6 +19,11 @@ func isAppImage() bool {
 	return os.Getenv("APPIMAGE") != "" || os.Getenv("APPDIR") != ""
 }
 
+// Check if running under Hyprland
+func isHyprland() bool {
+	return os.Getenv("HYPRLAND_INSTANCE_SIGNATURE") != ""
+}
+
 // Select the most appropriate hotkey provider based on configuration and environment.
 // Provider selection order (unless overridden in config):
 //  1. D-Bus GlobalShortcuts portal (Wayland-native, no extra permissions)
@@ -49,6 +54,9 @@ func selectAppImageProvider(logger logger.Logger) interfaces.KeyboardEventProvid
 	// D-Bus GlobalShortcuts portal requires no special permissions
 	if dbusProvider := providers.NewDbusKeyboardProvider(logger); dbusProvider.IsSupported() {
 		logger.Info("Using D-Bus keyboard provider (AppImage mode)")
+		if isHyprland() {
+			logger.Warning("Hyprland detected: hotkeys require manual binding in hyprland.conf — see docs/Desktop_Environment_Support.md")
+		}
 		return dbusProvider
 	}
 	logger.Info("D-Bus not available in AppImage, trying evdev...")
@@ -63,7 +71,10 @@ func selectAppImageProvider(logger logger.Logger) interfaces.KeyboardEventProvid
 func selectSystemProvider(logger logger.Logger) interfaces.KeyboardEventProvider {
 	// D-Bus GlobalShortcuts portal requires no special permissions
 	if dbusProvider := providers.NewDbusKeyboardProvider(logger); dbusProvider.IsSupported() {
-		logger.Info("Using D-Bus keyboard provider (GNOME/KDE)")
+		logger.Info("Using D-Bus keyboard provider")
+		if isHyprland() {
+			logger.Warning("Hyprland detected: hotkeys require manual binding in hyprland.conf — see docs/Desktop_Environment_Support.md")
+		}
 		return dbusProvider
 	}
 	logger.Info("D-Bus not available, trying evdev...")

--- a/hotkeys/manager/manager_linux.go
+++ b/hotkeys/manager/manager_linux.go
@@ -19,13 +19,17 @@ func isAppImage() bool {
 	return os.Getenv("APPIMAGE") != "" || os.Getenv("APPDIR") != ""
 }
 
-// Select the most appropriate hotkey provider based on configuration and environment
+// Select the most appropriate hotkey provider based on configuration and environment.
+// Provider selection order (unless overridden in config):
+//  1. D-Bus GlobalShortcuts portal (Wayland-native, no extra permissions)
+//  2. evdev (X11-era direct access, requires input group or udev rule)
+//  3. Dummy provider (hotkeys disabled, logs instructions)
+//
+// Override via config: hotkeys.provider = "dbus" | "evdev"
+// Any other value (including empty) triggers auto-selection.
 func selectProviderForEnvironment(config adapters.HotkeyConfig, environment interfaces.EnvironmentType, logger logger.Logger) interfaces.KeyboardEventProvider {
-	// Silence unused parameter warnings (reserved for future use)
-	_ = config
-	_ = environment
+	_ = environment // reserved for future environment-specific logic
 
-	// Handle an explicit provider override from the configuration
 	switch config.GetProvider() {
 	case "evdev":
 		logger.Info("Hotkeys provider override: evdev")
@@ -34,7 +38,6 @@ func selectProviderForEnvironment(config adapters.HotkeyConfig, environment inte
 		logger.Info("Hotkeys provider override: dbus")
 		return providers.NewDbusKeyboardProvider(logger)
 	}
-	// Auto-select the provider based on the runtime environment
 	if isAppImage() {
 		return selectAppImageProvider(logger)
 	}
@@ -43,32 +46,30 @@ func selectProviderForEnvironment(config adapters.HotkeyConfig, environment inte
 
 // Select the provider for an AppImage environment
 func selectAppImageProvider(logger logger.Logger) interfaces.KeyboardEventProvider {
-	logger.Info("AppImage detected - checking evdev first for better compatibility")
-	// Try evdev first, as it is often more reliable in AppImage contexts
+	// D-Bus GlobalShortcuts portal requires no special permissions
+	if dbusProvider := providers.NewDbusKeyboardProvider(logger); dbusProvider.IsSupported() {
+		logger.Info("Using D-Bus keyboard provider (AppImage mode)")
+		return dbusProvider
+	}
+	logger.Info("D-Bus not available in AppImage, trying evdev...")
 	if evdevProvider := providers.NewEvdevKeyboardProvider(logger); evdevProvider.IsSupported() {
 		logger.Info("Using evdev keyboard provider (AppImage mode)")
 		return evdevProvider
 	}
-	logger.Info("evdev not available in AppImage, falling back to D-Bus")
-	logger.Info("HOTKEY SETUP: For reliable hotkeys in AppImage, run:")
-	logger.Info("  sudo usermod -a -G input $USER")
-	logger.Info("  Then reboot or log out/in")
-	// Fallback to D-Bus if evdev is not available
-	return providers.NewDbusKeyboardProvider(logger)
+	return createFallbackProvider(logger)
 }
 
 // Select the provider for a standard system environment
 func selectSystemProvider(logger logger.Logger) interfaces.KeyboardEventProvider {
-	// Try evdev first - more reliable, works if user is in 'input' group
-	if evdevProvider := providers.NewEvdevKeyboardProvider(logger); evdevProvider.IsSupported() {
-		logger.Info("Using evdev keyboard provider")
-		return evdevProvider
-	}
-	logger.Info("evdev not available (user not in 'input' group?), trying D-Bus...")
-	// Fallback to D-Bus GlobalShortcuts portal
+	// D-Bus GlobalShortcuts portal requires no special permissions
 	if dbusProvider := providers.NewDbusKeyboardProvider(logger); dbusProvider.IsSupported() {
 		logger.Info("Using D-Bus keyboard provider (GNOME/KDE)")
 		return dbusProvider
+	}
+	logger.Info("D-Bus not available, trying evdev...")
+	if evdevProvider := providers.NewEvdevKeyboardProvider(logger); evdevProvider.IsSupported() {
+		logger.Info("Using evdev keyboard provider")
+		return evdevProvider
 	}
 
 	logger.Info("No hotkey provider available")
@@ -77,10 +78,9 @@ func selectSystemProvider(logger logger.Logger) interfaces.KeyboardEventProvider
 
 // Create a dummy provider as a last resort
 func createFallbackProvider(logger logger.Logger) interfaces.KeyboardEventProvider {
-	logger.Warning("No supported keyboard provider available")
-	logger.Info("For hotkeys to work:")
-	logger.Info("  - On GNOME/KDE: Ensure D-Bus session is running")
-	logger.Info("  - On other DEs: Run with sudo or add user to 'input' group")
-	logger.Info("  - Alternative: Use system-wide hotkey tools like sxhkd")
+	logger.Warning("No hotkey provider available — hotkeys will be disabled")
+	logger.Info("To enable hotkeys:")
+	logger.Info("  - GNOME/KDE: ensure xdg-desktop-portal is running")
+	logger.Info("  - Minimal WMs (i3, bspwm, etc.): enable evdev via 'provider: evdev' in config")
 	return providers.NewDummyKeyboardProvider(logger)
 }

--- a/hotkeys/providers/dbus_provider.go
+++ b/hotkeys/providers/dbus_provider.go
@@ -6,6 +6,7 @@
 package providers
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -48,9 +49,13 @@ func (p *DbusKeyboardProvider) IsSupported() bool {
 			p.logger.Error("Failed to close D-Bus connection: %v", err)
 		}
 	}()
-	// Check if the GlobalShortcuts portal is available by introspecting the desktop portal
+	// Probe with a short timeout — portal may be activatable but not yet running,
+	// which causes the default D-Bus timeout (25s) to block app startup.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
 	obj := conn.Object("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop")
-	call := obj.Call("org.freedesktop.DBus.Introspectable.Introspect", 0)
+	call := obj.CallWithContext(ctx, "org.freedesktop.DBus.Introspectable.Introspect", 0)
 	if call.Err != nil {
 		p.logger.Warning("D-Bus portal not available: %v", call.Err)
 		return false

--- a/packaging/appimage/AppRun
+++ b/packaging/appimage/AppRun
@@ -1,7 +1,7 @@
 #!/bin/bash
 # AppRun - Entry point for Dabri AppImage
 
-HERE="${APPDIR:-$(dirname "$(readlink -f "$0")"}"
+HERE="${APPDIR:-$(dirname "$(readlink -f "$0")")}"
 export PATH="${HERE}/usr/bin:${PATH}"
 export LD_LIBRARY_PATH="${HERE}/usr/lib:${LD_LIBRARY_PATH}"
 

--- a/packaging/appimage/AppRun
+++ b/packaging/appimage/AppRun
@@ -1,8 +1,7 @@
 #!/bin/bash
 # AppRun - Entry point for Dabri AppImage
 
-SELF=$(readlink -f "$0")
-HERE=${SELF%/*}
+HERE="${APPDIR:-$(dirname "$(readlink -f "$0")"}"
 export PATH="${HERE}/usr/bin:${PATH}"
 export LD_LIBRARY_PATH="${HERE}/usr/lib:${LD_LIBRARY_PATH}"
 
@@ -66,7 +65,7 @@ integrate_desktop() {
 [Desktop Entry]
 Name=Dabri
 Comment=Offline speech-to-text for AI assistants
-Exec="${SELF}" %U
+Exec="${APPIMAGE}" %U
 Icon=io.github.ashbuk.dabri
 Type=Application
 Categories=Utility;Audio;Accessibility;

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -173,6 +173,9 @@ build_appimage() {
         [ -n "$found" ] && lib_args="$lib_args --library $found" && echo "Will bundle: $found"
     done
 
+    # GTK version must be set explicitly — auto-detection fails on Go binaries
+    export DEPLOY_GTK_VERSION=3
+
     # Step 1: Use linuxdeploy to gather dependencies
     "${TOOLS_DIR}/linuxdeploy-${ARCH}.AppImage" --appimage-extract-and-run \
         --appdir "${APP_NAME}.AppDir" \

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -180,7 +180,7 @@ build_appimage() {
         $lib_args \
         --desktop-file "${APP_NAME}.AppDir/${APP_NAME}.desktop" \
         --icon-file "${APP_NAME}.AppDir/io.github.ashbuk.dabri.png" \
-        --plugin gtk || echo "Warning: linuxdeploy had issues, continuing..."
+        --plugin gtk
 
     # Remove unnecessary docs (licenses available in source repos)
     rm -rf "${APP_NAME}.AppDir/usr/share/doc"


### PR DESCRIPTION
Make D-Bus GlobalShortcuts the default hotkey provider (least privilege), with evdev as an explicit opt-in. Includes AppImage runtime fixes and Hyprland-specific setup guidance.