### PR TITLE
Sandbox/troubleshooting

### DIFF
--- a/audio/recorders/arecord_recorder.go
+++ b/audio/recorders/arecord_recorder.go
@@ -5,6 +5,7 @@ package recorders
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/AshBuk/dabri/v2/audio/processing"
 	"github.com/AshBuk/dabri/v2/config"
@@ -18,9 +19,16 @@ type ArecordRecorder struct {
 
 // Create a new instance of the arecord-based recorder
 func NewArecordRecorder(config *config.Config, logger logger.Logger, tempManager *processing.TempFileManager) *ArecordRecorder {
-	return &ArecordRecorder{
+	r := &ArecordRecorder{
 		BaseRecorder: NewBaseRecorder(config, logger, tempManager),
 	}
+	// In Flatpak, "arecord" is the bundled ffmpeg+pulse wrapper, which finalizes
+	// the WAV only on a clean "q" stop. Native arecord finalizes on signals, so
+	// the token stays disabled there.
+	if os.Getenv("FLATPAK_ID") != "" {
+		r.quitToken = []byte("q")
+	}
+	return r
 }
 
 // Start an audio recording using the `arecord` command

--- a/audio/recorders/base_recorder.go
+++ b/audio/recorders/base_recorder.go
@@ -20,6 +20,10 @@ import (
 	"github.com/AshBuk/dabri/v2/internal/logger"
 )
 
+// Time allowed for a process to finalize its output after a graceful stop
+// request (e.g. ffmpeg writing the WAV trailer) before escalating to signals.
+const gracefulQuitTimeout = 1500 * time.Millisecond
+
 // Implements common functionality for audio recorders
 type BaseRecorder struct {
 	config             *config.Config
@@ -35,6 +39,12 @@ type BaseRecorder struct {
 	audioLevelCallback interfaces.AudioLevelCallback // Callback for audio level updates
 	currentAudioLevel  float64                       // Current audio level (0.0 to 1.0)
 	levelMutex         sync.RWMutex                  // Mutex for audio level access
+
+	// Graceful stop: when quitToken is set, StopProcess first writes it to the
+	// process stdin (e.g. ffmpeg "q") so the process finalizes its own output
+	// before any signal escalation. Nil token keeps the signal-only behavior.
+	quitToken []byte
+	stdinPipe io.WriteCloser
 
 	// Diagnostics
 	stderrBuf bytes.Buffer
@@ -288,6 +298,12 @@ func (b *BaseRecorder) StopProcess() error {
 }
 
 func (b *BaseRecorder) attemptGracefulShutdown() {
+	// Prefer process-native graceful stop (e.g. ffmpeg "q" writes the file
+	// trailer) so output is finalized without a lossy SIGKILL.
+	if b.tryGracefulQuit() {
+		return
+	}
+
 	maxRetries := 3
 	for i := 0; i < maxRetries; i++ {
 		if i > 0 {
@@ -300,6 +316,31 @@ func (b *BaseRecorder) attemptGracefulShutdown() {
 
 		b.escalateToSIGKILL()
 		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// tryGracefulQuit asks the process to stop via its stdin token (e.g. ffmpeg
+// "q"), letting it finalize its output. Returns true if it exited in time.
+func (b *BaseRecorder) tryGracefulQuit() bool {
+	if len(b.quitToken) == 0 || b.stdinPipe == nil {
+		return false
+	}
+	if _, err := b.stdinPipe.Write(b.quitToken); err != nil {
+		b.logger.Debug("Graceful quit write failed: %v", err)
+		return false
+	}
+	// EOF on stdin also tells most tools to stop.
+	_ = b.stdinPipe.Close()
+
+	done := make(chan error, 1)
+	go func() { done <- b.waitForProcess() }()
+	select {
+	case err := <-done:
+		b.logProcessExit(err)
+		return true
+	case <-time.After(gracefulQuitTimeout):
+		b.logger.Warning("Graceful quit timed out, escalating to signals")
+		return false
 	}
 }
 
@@ -363,6 +404,10 @@ func (b *BaseRecorder) cleanup() {
 	if b.cancel != nil {
 		b.cancel()
 	}
+	if b.stdinPipe != nil {
+		_ = b.stdinPipe.Close()
+		b.stdinPipe = nil
+	}
 
 	b.logStderr()
 
@@ -419,6 +464,15 @@ func (b *BaseRecorder) ExecuteRecordingCommand(cmdName string, args []string) er
 	// Capture stderr for diagnostics
 	b.stderrBuf.Reset()
 	b.cmd.Stderr = &b.stderrBuf
+	// Wire a controlled stdin pipe for graceful shutdown when requested
+	if len(b.quitToken) > 0 {
+		stdin, err := b.cmd.StdinPipe()
+		if err != nil {
+			b.cancel()
+			return fmt.Errorf("failed to create stdin pipe: %w", err)
+		}
+		b.stdinPipe = stdin
+	}
 	// If using a buffer, set up a pipe to read stdout for audio level monitoring
 	if b.useBuffer {
 		stdout, err := b.cmd.StdoutPipe()

--- a/audio/recorders/ffmpeg_recorder.go
+++ b/audio/recorders/ffmpeg_recorder.go
@@ -172,7 +172,7 @@ func (f *FFmpegRecorder) buildBaseCommandArgs() []string {
 	fragmentBytes := (sr / 50) * 2 // bytes, 16-bit mono
 	args := []string{
 		"-hide_banner",
-		"-y",                  // Overwrite output file if it exists
+		"-y",                   // Overwrite output file if it exists
 		"-fflags", "+nobuffer", // Reduce demuxer (input) buffering for low latency
 		// Input options must precede the input specification
 		"-analyzeduration", "0", // Start processing immediately, skip long stream analysis

--- a/audio/recorders/ffmpeg_recorder.go
+++ b/audio/recorders/ffmpeg_recorder.go
@@ -34,9 +34,14 @@ type FFmpegRecorder struct {
 
 // Create a new instance of the ffmpeg-based recorder
 func NewFFmpegRecorder(config *config.Config, logger logger.Logger, tempManager *processing.TempFileManager) *FFmpegRecorder {
-	return &FFmpegRecorder{
+	r := &FFmpegRecorder{
 		BaseRecorder: NewBaseRecorder(config, logger, tempManager),
 	}
+	// ffmpeg finalizes the WAV trailer (correct header sizes) only on a clean
+	// stop; reading "q" on stdin triggers that, whereas signals can leave it
+	// SIGKILL'd with an unfinalized header that decoders read as empty.
+	r.quitToken = []byte("q")
+	return r
 }
 
 // Resolve PulseAudio source name if "default" is specified
@@ -157,7 +162,8 @@ func (f *FFmpegRecorder) StopRecording() (string, error) {
 func (f *FFmpegRecorder) buildBaseCommandArgs() []string {
 	// Resolve actual PulseAudio source name (ffmpeg needs explicit source, not "default")
 	device := f.resolvePulseAudioSource(f.config.Audio.Device)
-	// Stable command with optimized options; avoid stdin to let SIGINT be handled cleanly
+	// Stable command with optimized options; stdin stays open so a "q" can
+	// stop ffmpeg cleanly and let it finalize the WAV header.
 	sr := f.config.Audio.SampleRate
 	if sr <= 0 {
 		sr = 16000
@@ -165,10 +171,9 @@ func (f *FFmpegRecorder) buildBaseCommandArgs() []string {
 	// Reduce PulseAudio buffering to lower start latency (~20ms fragments)
 	fragmentBytes := (sr / 50) * 2 // bytes, 16-bit mono
 	args := []string{
-		"-nostdin",
 		"-hide_banner",
-		"-y",                                 // Overwrite output file if it exists
-		"-fflags", "+nobuffer+flush_packets", // Reduce demuxer buffering and flush aggressively
+		"-y",                  // Overwrite output file if it exists
+		"-fflags", "+nobuffer", // Reduce demuxer (input) buffering for low latency
 		// Input options must precede the input specification
 		"-analyzeduration", "0", // Start processing immediately, skip long stream analysis
 		"-probesize", "32k", // Smaller probe size for faster start
@@ -188,6 +193,7 @@ func (f *FFmpegRecorder) buildBaseCommandArgs() []string {
 		"-vn", "-sn", // Disable video/subtitles just in case
 		"-c:a", "pcm_s16le",
 		"-q:a", "0",
+		"-flush_packets", "1", // Flush output muxer to disk per packet (avoid data loss on stop)
 	}
 
 	// Configure the output format

--- a/docs/Desktop_Environment_Support.md
+++ b/docs/Desktop_Environment_Support.md
@@ -41,8 +41,9 @@ Dabri therefore selects automatically:
 | **GNOME / KDE** | RemoteDesktop portal | None — one-time permission dialog |
 | **Hyprland / wlroots / Sway** | ydotool (uinput) | Opt-in (see below) |
 
-The portal path needs no extra permissions. For wlroots/Hyprland auto-typing,
-grant uinput access once (otherwise Dabri falls back to clipboard):
+The portal path is provided by [go-wlportal](https://github.com/AshBuk/go-wlportal)
+and needs no extra permissions. For wlroots/Hyprland auto-typing, grant uinput
+access once (otherwise Dabri falls back to clipboard):
 
 ```bash
 # 1) Allow the sandbox to see /dev/uinput

--- a/docs/Desktop_Environment_Support.md
+++ b/docs/Desktop_Environment_Support.md
@@ -21,16 +21,41 @@ sudo pacman -S gnome-shell-extension-appindicator
 
 | Desktop Environment | Primary Tool | Fallback | Status |
 |---------------------|--------------|----------|--------|
-| **🟢 GNOME+Wayland** | ydotool | clipboard | ⚠️ Requires setup |
-| **🟢 KDE+Wayland** | wtype → ydotool | clipboard | ✅ Auto-detected |
+| **🟢 GNOME+Wayland** | RemoteDesktop portal → ydotool | clipboard | ✅ Auto-detected |
+| **🟢 KDE+Wayland** | RemoteDesktop portal → wtype | clipboard | ✅ Auto-detected |
 | **🟢 Sway/Other Wayland** | wtype → ydotool | clipboard | ✅ Auto-detected |
 | **🟢 X11 (all DEs)** | xdotool | clipboard | ✅ Works out-of-box |
 
- GNOME/Wayland requires ydotool setup. 
- 
- Other Wayland compositors (KDE, Sway, etc.) works with wtype out of the box.
+ GNOME/KDE use the RemoteDesktop portal when available (one-time permission dialog), with a tool/clipboard fallback.
 
-## Direct typing on Wayland - Tool options
+ Other Wayland compositors (Sway, Hyprland, etc.) use wtype out of the box.
+
+### Flatpak
+
+Inside the sandbox `wtype` cannot work: the Wayland security-context blocks its
+virtual-keyboard protocol on wlroots/Hyprland, and GNOME/KDE never exposed it.
+Dabri therefore selects automatically:
+
+| Compositor | Active-window typing | Setup |
+|------------|----------------------|-------|
+| **GNOME / KDE** | RemoteDesktop portal | None — one-time permission dialog |
+| **Hyprland / wlroots / Sway** | ydotool (uinput) | Opt-in (see below) |
+
+The portal path needs no extra permissions. For wlroots/Hyprland auto-typing,
+grant uinput access once (otherwise Dabri falls back to clipboard):
+
+```bash
+# 1) Allow the sandbox to see /dev/uinput
+flatpak override --user --device=all io.github.ashbuk.dabri
+# 2) Allow non-root access to /dev/uinput on the host (if not already granted)
+echo 'KERNEL=="uinput", GROUP="input", MODE="0660"' | sudo tee /etc/udev/rules.d/99-uinput.rules
+sudo udevadm control --reload && sudo udevadm trigger
+sudo usermod -a -G input $USER   # re-login required
+```
+
+Dabri starts its own `ydotoold` inside the sandbox when uinput is accessible.
+
+## Direct typing on Wayland - Tool options (native)
 
 The application automatically selects the best available typing tool:
 - **wtype**: Works without setup on non-GNOME Wayland compositors (KDE, Sway, etc.). Automatically selected if available.
@@ -168,4 +193,4 @@ Add to `~/.config/hypr/hyprland.conf`:
 exec-once = dabri
 ```
 
-*Last updated: 2026-05-21*
+*Last updated: 2026-06-05*

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 )
 
 require (
+	github.com/AshBuk/go-wlportal v0.1.0
 	github.com/ggerganov/whisper.cpp/bindings/go v0.0.0-20260601115620-23ee03506a91
 	github.com/go-audio/wav v1.1.0
 	github.com/godbus/dbus/v5 v5.2.2

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 )
 
 require (
-	github.com/AshBuk/go-wlportal v0.1.0
+	github.com/AshBuk/go-wlportal v0.2.0
 	github.com/ggerganov/whisper.cpp/bindings/go v0.0.0-20260601115620-23ee03506a91
 	github.com/go-audio/wav v1.1.0
 	github.com/godbus/dbus/v5 v5.2.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 fyne.io/systray v1.12.0 h1:CA1Kk0e2zwFlxtc02L3QFSiIbxJ/P0n582YrZHT7aTM=
 fyne.io/systray v1.12.0/go.mod h1:RVwqP9nYMo7h5zViCBHri2FgjXF7H2cub7MAq4NSoLs=
+github.com/AshBuk/go-wlportal v0.1.0 h1:qd6rbYwV+1usBsOH9RP0UwZOhlbYc4eVDN+0/b9ZEs0=
+github.com/AshBuk/go-wlportal v0.1.0/go.mod h1:/gHO8KLdr8/IgCzGtb84aKVuto2FIlMcLnB09MubuAY=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 fyne.io/systray v1.12.0 h1:CA1Kk0e2zwFlxtc02L3QFSiIbxJ/P0n582YrZHT7aTM=
 fyne.io/systray v1.12.0/go.mod h1:RVwqP9nYMo7h5zViCBHri2FgjXF7H2cub7MAq4NSoLs=
-github.com/AshBuk/go-wlportal v0.1.0 h1:qd6rbYwV+1usBsOH9RP0UwZOhlbYc4eVDN+0/b9ZEs0=
-github.com/AshBuk/go-wlportal v0.1.0/go.mod h1:/gHO8KLdr8/IgCzGtb84aKVuto2FIlMcLnB09MubuAY=
+github.com/AshBuk/go-wlportal v0.2.0 h1:FuUPy2S8gmJWhY5ta/9ArEWy1OZDtwFv4XyMwnYXtyU=
+github.com/AshBuk/go-wlportal v0.2.0/go.mod h1:/gHO8KLdr8/IgCzGtb84aKVuto2FIlMcLnB09MubuAY=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/hotkeys/manager/manager_linux.go
+++ b/hotkeys/manager/manager_linux.go
@@ -12,16 +12,12 @@ import (
 	"github.com/AshBuk/dabri/v2/hotkeys/interfaces"
 	"github.com/AshBuk/dabri/v2/hotkeys/providers"
 	"github.com/AshBuk/dabri/v2/internal/logger"
+	"github.com/AshBuk/dabri/v2/internal/platform"
 )
 
 // Check if running inside AppImage
 func isAppImage() bool {
 	return os.Getenv("APPIMAGE") != "" || os.Getenv("APPDIR") != ""
-}
-
-// Check if running inside Flatpak
-func isFlatpak() bool {
-	return os.Getenv("FLATPAK_ID") != ""
 }
 
 // Check if running under Hyprland
@@ -49,7 +45,7 @@ func selectProviderForEnvironment(config adapters.HotkeyConfig, environment inte
 		return providers.NewDbusKeyboardProvider(logger)
 	}
 	// Auto-select the provider based on the runtime environment
-	if isFlatpak() {
+	if platform.IsFlatpak() {
 		logger.Info("Flatpak detected - using D-Bus keyboard provider")
 		return providers.NewDbusKeyboardProvider(logger)
 	}

--- a/hotkeys/providers/dbus_provider.go
+++ b/hotkeys/providers/dbus_provider.go
@@ -6,67 +6,39 @@
 package providers
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/AshBuk/go-wlportal/shortcuts"
+
 	"github.com/AshBuk/dabri/v2/hotkeys/utils"
 	"github.com/AshBuk/dabri/v2/internal/logger"
-	dbus "github.com/godbus/dbus/v5"
 )
 
-// Implements KeyboardEventProvider using the D-Bus GlobalShortcuts portal
+// Implements KeyboardEventProvider using the GlobalShortcuts portal through the
+// go-wlportal/shortcuts adapter.
 type DbusKeyboardProvider struct {
-	callbacks     map[string]func() error
-	conn          *dbus.Conn
-	sessionHandle string
-	isListening   bool
-	mutex         sync.Mutex
-	logger        logger.Logger
-	wg            sync.WaitGroup // Tracks listener goroutine
+	callbacks   map[string]func() error
+	session     *shortcuts.Session
+	isListening bool
+	mutex       sync.Mutex
+	logger      logger.Logger
+	wg          sync.WaitGroup // Tracks listener goroutine
 }
 
 // Create a new D-Bus keyboard provider
 func NewDbusKeyboardProvider(logger logger.Logger) *DbusKeyboardProvider {
 	return &DbusKeyboardProvider{
-		callbacks:   make(map[string]func() error),
-		isListening: false,
-		logger:      logger,
+		callbacks: make(map[string]func() error),
+		logger:    logger,
 	}
 }
 
 // Check if the D-Bus GlobalShortcuts portal is available
 func (p *DbusKeyboardProvider) IsSupported() bool {
-	conn, err := dbus.ConnectSessionBus()
-	if err != nil {
-		p.logger.Warning("D-Bus session bus not available: %v", err)
-		return false
-	}
-	defer func() {
-		if err := conn.Close(); err != nil {
-			p.logger.Error("Failed to close D-Bus connection: %v", err)
-		}
-	}()
-	// Probe with a short timeout — portal may be activatable but not yet running,
-	// which causes the default D-Bus timeout (25s) to block app startup.
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	obj := conn.Object("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop")
-	call := obj.CallWithContext(ctx, "org.freedesktop.DBus.Introspectable.Introspect", 0)
-	if call.Err != nil {
-		p.logger.Warning("D-Bus portal not available: %v", call.Err)
-		return false
-	}
-
-	var introspectData string
-	if err := call.Store(&introspectData); err != nil {
-		p.logger.Error("Failed to get introspection data: %v", err)
-		return false
-	}
-	if len(introspectData) > 0 && containsGlobalShortcuts(introspectData) {
+	if shortcuts.Available() {
 		p.logger.Info("D-Bus portal GlobalShortcuts detected")
 		return true
 	}
@@ -74,63 +46,7 @@ func (p *DbusKeyboardProvider) IsSupported() bool {
 	return false
 }
 
-// Check if the introspection data contains the GlobalShortcuts interface
-func containsGlobalShortcuts(data string) bool {
-	return strings.Contains(data, "GlobalShortcuts")
-}
-
-// Start listening for D-Bus hotkey events
-func (p *DbusKeyboardProvider) Start() error {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	if p.isListening {
-		return fmt.Errorf("D-Bus keyboard provider already started")
-	}
-
-	var err error
-	p.conn, err = dbus.ConnectSessionBus()
-	if err != nil {
-		return fmt.Errorf("failed to connect to session bus (D-Bus unavailable): %w", err)
-	}
-	// Register hotkeys via the GlobalShortcuts portal
-	if err := p.registerHotkeys(); err != nil {
-		if closeErr := p.conn.Close(); closeErr != nil {
-			p.logger.Error("Failed to close D-Bus connection: %v", closeErr)
-		}
-		p.logger.Error("DBus GlobalShortcuts binding failed: %v", err)
-		p.logger.Info("Hint: In AppImage/sandboxed environments, global shortcuts may require user consent")
-		return fmt.Errorf("failed to register hotkeys (GlobalShortcuts portal unavailable): %w", err)
-	}
-	p.isListening = true
-	p.logger.Info("D-Bus hotkey provider started successfully")
-	return nil
-}
-
-// Stop the D-Bus hotkey listener
-func (p *DbusKeyboardProvider) Stop() {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	if !p.isListening {
-		return
-	}
-	// Close D-Bus connection to unblock signal channel
-	if p.conn != nil {
-		if err := p.conn.Close(); err != nil {
-			p.logger.Error("Failed to close D-Bus connection: %v", err)
-		}
-		p.conn = nil
-	}
-
-	p.isListening = false
-	// Wait for listener goroutine to exit
-	p.wg.Wait()
-
-	p.logger.Info("D-Bus hotkey provider stopped")
-}
-
-// Register a hotkey and its callback
+// Register a hotkey and its callback. Binding is deferred until Start.
 func (p *DbusKeyboardProvider) RegisterHotkey(hotkey string, callback func() error) error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
@@ -144,12 +60,95 @@ func (p *DbusKeyboardProvider) RegisterHotkey(hotkey string, callback func() err
 	return nil
 }
 
+// Start binds all registered hotkeys via the GlobalShortcuts portal and listens
+// for their activations.
+func (p *DbusKeyboardProvider) Start() error {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	if p.isListening {
+		return fmt.Errorf("D-Bus keyboard provider already started")
+	}
+
+	// Build the shortcut list; the hotkey string doubles as the portal ID echoed
+	// back on activation, so callbacks can be looked up by it directly.
+	list := make([]shortcuts.Shortcut, 0, len(p.callbacks))
+	for hotkey := range p.callbacks {
+		accel := convertHotkeyToAccelerator(hotkey)
+		p.logger.Info("DBus: Converting hotkey '%s' to accelerator '%s'", hotkey, accel)
+		list = append(list, shortcuts.Shortcut{
+			ID:               hotkey,
+			Description:      fmt.Sprintf("Dabri hotkey: %s", hotkey),
+			PreferredTrigger: accel,
+		})
+	}
+
+	session, err := shortcuts.New(list)
+	if err != nil {
+		p.logger.Error("DBus GlobalShortcuts binding failed: %v", err)
+		p.logger.Info("Hint: In AppImage/sandboxed environments, global shortcuts may require user consent")
+		return fmt.Errorf("failed to register hotkeys (GlobalShortcuts portal unavailable): %w", err)
+	}
+	p.session = session
+	p.isListening = true
+
+	// Pass the channel explicitly so the goroutine never reads p.session, which
+	// Stop clears under the lock.
+	p.wg.Add(1)
+	go p.listen(session.Events())
+
+	p.logger.Info("D-Bus hotkey provider started successfully")
+	return nil
+}
+
+// Stop ends the portal session and waits for the listener goroutine to exit.
+func (p *DbusKeyboardProvider) Stop() {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	if !p.isListening {
+		return
+	}
+	// Closing the session closes its Events channel, which ends the listener.
+	if p.session != nil {
+		if err := p.session.Close(); err != nil {
+			p.logger.Error("Failed to close GlobalShortcuts session: %v", err)
+		}
+		p.session = nil
+	}
+
+	p.isListening = false
+	// Wait for listener goroutine to exit
+	p.wg.Wait()
+
+	p.logger.Info("D-Bus hotkey provider stopped")
+}
+
 // SupportsCaptureOnce returns false as D-Bus GlobalShortcuts portal doesn't support one-shot capture
 func (p *DbusKeyboardProvider) SupportsCaptureOnce() bool { return false }
 
 // Return an error as this provider does not support capture-once functionality
 func (p *DbusKeyboardProvider) CaptureOnce(timeout time.Duration) (string, error) {
 	return "", fmt.Errorf("captureOnce not supported in dbus provider")
+}
+
+// listen dispatches callbacks for activated shortcuts until the session closes.
+// The callbacks map is read-only after Start, so no lock is taken here.
+func (p *DbusKeyboardProvider) listen(events <-chan shortcuts.Event) {
+	defer p.wg.Done()
+	for e := range events {
+		if !e.Pressed {
+			continue
+		}
+		callback, exists := p.callbacks[e.ID]
+		if !exists {
+			continue
+		}
+		p.logger.Info("Hotkey activated: %s", e.ID)
+		if err := callback(); err != nil {
+			p.logger.Error("Error executing hotkey callback: %v", err)
+		}
+	}
 }
 
 // Convert a hotkey string to a desktop-portal accelerator string
@@ -193,161 +192,4 @@ func convertHotkeyToAccelerator(hotkey string) string {
 		key = "Delete"
 	}
 	return prefix.String() + key
-}
-
-// Register all hotkeys using the GlobalShortcuts portal
-func (p *DbusKeyboardProvider) registerHotkeys() error {
-	obj := p.conn.Object("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop")
-
-	// Generate unique token for this request
-	handleToken := fmt.Sprintf("dabri_%d", time.Now().UnixNano())
-	sessionHandleToken := fmt.Sprintf("dabri_session_%d", time.Now().UnixNano())
-
-	// Build expected request path from sender name and token
-	senderName := strings.ReplaceAll(p.conn.Names()[0], ".", "_")
-	senderName = strings.TrimPrefix(senderName, ":")
-	expectedRequestPath := dbus.ObjectPath(fmt.Sprintf("/org/freedesktop/portal/desktop/request/%s/%s", senderName, handleToken))
-
-	p.logger.Info("DBus: Expected request path: %s", expectedRequestPath)
-
-	// Subscribe to Response signal BEFORE calling CreateSession to avoid race condition
-	signalChan := make(chan *dbus.Signal, 1)
-	p.conn.Signal(signalChan)
-	defer p.conn.RemoveSignal(signalChan)
-
-	rule := fmt.Sprintf("type='signal',interface='org.freedesktop.portal.Request',member='Response',path='%s'", expectedRequestPath)
-	if err := p.conn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, rule).Err; err != nil {
-		return fmt.Errorf("failed to add match rule: %w", err)
-	}
-
-	// Step 1: Create a session using Request/Response pattern
-	sessionOptions := map[string]dbus.Variant{
-		"handle_token":         dbus.MakeVariant(handleToken),
-		"session_handle_token": dbus.MakeVariant(sessionHandleToken),
-	}
-	call := obj.Call("org.freedesktop.portal.GlobalShortcuts.CreateSession", 0, sessionOptions)
-	if call.Err != nil {
-		return fmt.Errorf("failed to create GlobalShortcuts session: %w", call.Err)
-	}
-
-	// Wait for the Response signal to get the session handle
-	sessionHandle, err := p.waitForSessionResponseOnChannel(signalChan, expectedRequestPath)
-	if err != nil {
-		return fmt.Errorf("failed to get session handle: %w", err)
-	}
-	p.sessionHandle = sessionHandle
-	// Step 2: Prepare shortcuts for binding (include accelerator)
-	// Format according to GlobalShortcuts portal spec: a(sa{sv})
-	shortcuts := make([]struct {
-		ID   string
-		Data map[string]dbus.Variant
-	}, 0, len(p.callbacks))
-	for hotkey := range p.callbacks {
-		accel := convertHotkeyToAccelerator(hotkey)
-		p.logger.Info("DBus: Converting hotkey '%s' to accelerator '%s'", hotkey, accel)
-
-		shortcutData := map[string]dbus.Variant{
-			"description":       dbus.MakeVariant(fmt.Sprintf("Dabri hotkey: %s", hotkey)),
-			"preferred_trigger": dbus.MakeVariant(accel),
-		}
-		shortcuts = append(shortcuts, struct {
-			ID   string
-			Data map[string]dbus.Variant
-		}{
-			ID:   hotkey,
-			Data: shortcutData,
-		})
-	}
-	// Step 3: Bind shortcuts to the session
-	bindOptions := map[string]dbus.Variant{}
-	p.logger.Info("DBus: Binding %d shortcuts to session %s", len(shortcuts), sessionHandle)
-
-	call = obj.Call("org.freedesktop.portal.GlobalShortcuts.BindShortcuts", 0,
-		dbus.ObjectPath(sessionHandle), shortcuts, "", bindOptions)
-	if call.Err != nil {
-		return fmt.Errorf("failed to bind shortcuts: %w", call.Err)
-	}
-
-	p.logger.Info("DBus: Successfully bound shortcuts")
-	// Step 4: Start listening for shortcut activations in tracked goroutine
-	p.wg.Add(1)
-	go func() {
-		defer p.wg.Done()
-		p.listenForShortcuts()
-	}()
-	return nil
-}
-
-// Wait for the Response signal on a pre-subscribed channel
-func (p *DbusKeyboardProvider) waitForSessionResponseOnChannel(signalChan chan *dbus.Signal, expectedPath dbus.ObjectPath) (string, error) {
-	timeout := time.After(5 * time.Second)
-	for {
-		select {
-		case sig := <-signalChan:
-			p.logger.Info("DBus: Received signal %s on path %s", sig.Name, sig.Path)
-			if sig.Name == "org.freedesktop.portal.Request.Response" && sig.Path == expectedPath {
-				if len(sig.Body) >= 2 {
-					// Body[0] is response code, Body[1] is results
-					// Response codes: 0=success, 1=user cancelled, 2=other error/rejected
-					responseCode, ok := sig.Body[0].(uint32)
-					if !ok || responseCode != 0 {
-						if responseCode == 1 {
-							return "", fmt.Errorf("user cancelled the permission dialog")
-						}
-						if responseCode == 2 {
-							return "", fmt.Errorf("permission denied - GlobalShortcuts requires app to be installed or user approval")
-						}
-						return "", fmt.Errorf("CreateSession request failed with code %v", responseCode)
-					}
-
-					results, ok := sig.Body[1].(map[string]dbus.Variant)
-					if !ok {
-						return "", fmt.Errorf("invalid results format in Response signal")
-					}
-
-					sessionHandleVariant, exists := results["session_handle"]
-					if !exists {
-						return "", fmt.Errorf("session_handle not found in Response results")
-					}
-
-					sessionHandle, ok := sessionHandleVariant.Value().(string)
-					if !ok {
-						return "", fmt.Errorf("invalid session_handle type in Response results")
-					}
-
-					return sessionHandle, nil
-				}
-			}
-			// Continue waiting for the expected signal
-		case <-timeout:
-			return "", fmt.Errorf("timeout waiting for CreateSession response")
-		}
-	}
-}
-
-// Listen for shortcut activation signals from the GlobalShortcuts portal
-func (p *DbusKeyboardProvider) listenForShortcuts() {
-	rule := "type='signal',interface='org.freedesktop.portal.GlobalShortcuts',member='Activated',path='/org/freedesktop/portal/desktop'"
-	p.conn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, rule)
-	// Listen for signals
-	c := make(chan *dbus.Signal, 10)
-	p.conn.Signal(c)
-
-	for sig := range c {
-		if sig.Name == "org.freedesktop.portal.GlobalShortcuts.Activated" {
-			if len(sig.Body) >= 2 {
-				// Body[0] is session handle, Body[1] is shortcut_id
-				if sessionHandle, ok := sig.Body[0].(dbus.ObjectPath); ok && string(sessionHandle) == p.sessionHandle {
-					if shortcutId, ok := sig.Body[1].(string); ok {
-						if callback, exists := p.callbacks[shortcutId]; exists {
-							p.logger.Info("Hotkey activated: %s", shortcutId)
-							if err := callback(); err != nil {
-								p.logger.Error("Error executing hotkey callback: %v", err)
-							}
-						}
-					}
-				}
-			}
-		}
-	}
 }

--- a/hotkeys/providers/dbus_provider.go
+++ b/hotkeys/providers/dbus_provider.go
@@ -327,8 +327,7 @@ func (p *DbusKeyboardProvider) waitForSessionResponseOnChannel(signalChan chan *
 
 // Listen for shortcut activation signals from the GlobalShortcuts portal
 func (p *DbusKeyboardProvider) listenForShortcuts() {
-	// Add a signal match rule for the session
-	rule := fmt.Sprintf("type='signal',interface='org.freedesktop.portal.GlobalShortcuts',member='Activated',path='%s'", p.sessionHandle)
+	rule := "type='signal',interface='org.freedesktop.portal.GlobalShortcuts',member='Activated',path='/org/freedesktop/portal/desktop'"
 	p.conn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, rule)
 	// Listen for signals
 	c := make(chan *dbus.Signal, 10)

--- a/hotkeys/providers/dbus_provider_test.go
+++ b/hotkeys/providers/dbus_provider_test.go
@@ -123,45 +123,7 @@ func TestDbusKeyboardProvider_Stop_WhenStarted(t *testing.T) {
 	if provider.isListening {
 		t.Error("expected isListening to be false after stop")
 	}
-	if provider.conn != nil {
-		t.Error("expected connection to be nil after stop")
-	}
-}
-
-func TestContainsGlobalShortcuts(t *testing.T) {
-	tests := []struct {
-		name     string
-		data     string
-		expected bool
-	}{
-		{
-			name:     "contains GlobalShortcuts",
-			data:     `<interface name="org.freedesktop.portal.GlobalShortcuts">`,
-			expected: true,
-		},
-		{
-			name:     "does not contain GlobalShortcuts",
-			data:     `<interface name="org.freedesktop.portal.FileChooser">`,
-			expected: false,
-		},
-		{
-			name:     "empty data",
-			data:     "",
-			expected: false,
-		},
-		{
-			name:     "contains partial match",
-			data:     "Some text with Global but not the full interface",
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := containsGlobalShortcuts(tt.data)
-			if result != tt.expected {
-				t.Errorf("containsGlobalShortcuts(%q) = %v, want %v", tt.data, result, tt.expected)
-			}
-		})
+	if provider.session != nil {
+		t.Error("expected session to be nil after stop")
 	}
 }

--- a/internal/platform/environment.go
+++ b/internal/platform/environment.go
@@ -67,6 +67,15 @@ func IsGNOME() bool {
 	return de == "GNOME" || de == "ubuntu:GNOME"
 }
 
+// IsFlatpak reports whether the process runs inside a Flatpak sandbox
+func IsFlatpak() bool {
+	if os.Getenv("FLATPAK_ID") != "" {
+		return true
+	}
+	_, err := os.Stat("/.flatpak-info")
+	return err == nil
+}
+
 // HasStatusNotifierWatcher checks if a StatusNotifier watcher is present on the session D-Bus
 func HasStatusNotifierWatcher() bool {
 	conn, err := dbus.SessionBus()

--- a/internal/services/factory.go
+++ b/internal/services/factory.go
@@ -16,6 +16,7 @@ import (
 	"github.com/AshBuk/dabri/v2/internal/platform"
 	"github.com/AshBuk/dabri/v2/internal/tray"
 	outputInterfaces "github.com/AshBuk/dabri/v2/output/interfaces"
+	"github.com/AshBuk/dabri/v2/output/outputters"
 	"github.com/AshBuk/dabri/v2/websocket"
 	"github.com/AshBuk/dabri/v2/whisper"
 )
@@ -41,6 +42,7 @@ type Components struct {
 	TrayManager     tray.Manager                // System tray icon and menu
 	NotifyManager   *notify.NotificationManager // Desktop notifications
 	TempFileManager *processing.TempFileManager // Temporary audio file management
+	InputDaemon     *outputters.YdotoolDaemon   // ydotoold for active-window typing (Flatpak/wlroots)
 }
 
 // ServiceFactory creates and configures all services with proper dependency injection

--- a/internal/services/factory_assembler.go
+++ b/internal/services/factory_assembler.go
@@ -59,6 +59,7 @@ func (sa *FactoryAssembler) Assemble(components *Components) *ServiceContainer {
 	container.UI = uiSvc
 	container.IO = ioSvc
 	container.TempFileManager = components.TempFileManager
+	container.InputDaemon = components.InputDaemon
 
 	// Step 4: Late wiring - cross-dependencies after container is ready
 	audioSvc.SetDependencies(container.UI, container.IO)

--- a/internal/services/factory_components.go
+++ b/internal/services/factory_components.go
@@ -14,6 +14,7 @@ import (
 	"github.com/AshBuk/dabri/v2/hotkeys/adapters"
 	"github.com/AshBuk/dabri/v2/hotkeys/manager"
 	"github.com/AshBuk/dabri/v2/internal/notify"
+	"github.com/AshBuk/dabri/v2/internal/platform"
 	"github.com/AshBuk/dabri/v2/internal/tray"
 	outputFactory "github.com/AshBuk/dabri/v2/output/factory"
 	outputInterfaces "github.com/AshBuk/dabri/v2/output/interfaces"
@@ -85,6 +86,8 @@ func (cf *FactoryComponents) InitializeComponents() (*Components, error) {
 			return nil, fmt.Errorf("failed to initialize any output manager")
 		}
 	}
+	// Start ydotoold when ydotool is the chosen typing backend (Flatpak/wlroots)
+	components.InputDaemon = cf.startInputDaemonIfNeeded(components.OutputManager)
 	// Initialize hotkey manager
 	components.HotkeyManager = cf.createHotkeyManager()
 	// Initialize WebSocket server (always initialized but may not be started).
@@ -139,6 +142,24 @@ func (cf *FactoryComponents) createFallbackOutputManager(outputEnv outputFactory
 		// Restore original mode if fallback failed
 		cf.config.Config.Output.DefaultMode = oldMode
 	}
+	return nil
+}
+
+// startInputDaemonIfNeeded launches ydotoold only when ydotool is the resolved
+// typing backend inside Flatpak. Returns nil otherwise (portal/clipboard/native),
+// and logs guidance when uinput access is missing so typing degrades to clipboard.
+func (cf *FactoryComponents) startInputDaemonIfNeeded(out outputInterfaces.Outputter) *outputters.YdotoolDaemon {
+	if out == nil || !platform.IsFlatpak() {
+		return nil
+	}
+	if _, typeTool := out.GetToolNames(); typeTool != "ydotool" {
+		return nil
+	}
+	if daemon := outputters.StartYdotoolDaemon(); daemon != nil {
+		cf.config.Logger.Info("Started ydotoold for active-window typing")
+		return daemon
+	}
+	cf.config.Logger.Warning("Active-window typing needs uinput access; run 'flatpak override --user --device=all io.github.ashbuk.dabri' (see docs) — falling back to clipboard otherwise")
 	return nil
 }
 

--- a/internal/services/interfaces.go
+++ b/internal/services/interfaces.go
@@ -11,6 +11,7 @@ import (
 	"github.com/AshBuk/dabri/v2/audio/processing"
 	"github.com/AshBuk/dabri/v2/config"
 	"github.com/AshBuk/dabri/v2/hotkeys/adapters"
+	"github.com/AshBuk/dabri/v2/output/outputters"
 )
 
 // AudioServiceInterface defines the contract for audio-related operations
@@ -152,6 +153,7 @@ type ServiceContainer struct {
 	Config          ConfigServiceInterface
 	Hotkeys         HotkeyServiceInterface
 	TempFileManager *processing.TempFileManager
+	InputDaemon     *outputters.YdotoolDaemon
 }
 
 // Create a new service container with all services
@@ -190,6 +192,9 @@ func (sc *ServiceContainer) Shutdown() error {
 	if sc.TempFileManager != nil {
 		sc.TempFileManager.Stop()
 		sc.TempFileManager.CleanupAll()
+	}
+	if sc.InputDaemon != nil {
+		sc.InputDaemon.Stop()
 	}
 
 	return errors.Join(errs...)

--- a/internal/services/ui_service.go
+++ b/internal/services/ui_service.go
@@ -104,7 +104,7 @@ func (us *UIService) ShowAboutPage() error {
 	}
 	path := filepath.Join(cacheDir, "dabri-about.html")
 	html := strings.Replace(assets.AboutHTML, "{{VERSION}}", appversion.Version, 1)
-	if err := os.WriteFile(path, []byte(html), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(html), 0o600); err != nil {
 		return fmt.Errorf("failed to write about page: %w", err)
 	}
 	return us.openWithSystem(path)

--- a/internal/services/ui_service.go
+++ b/internal/services/ui_service.go
@@ -92,22 +92,22 @@ func (us *UIService) SetSuccess(message string) {
 	}
 }
 
-// Create temporary HTML file and open with system browser
+// Write the About HTML to a cache file and open it with the system browser.
+// We use the user cache dir rather than os.TempDir(): under Flatpak the latter
+// is the sandbox-private /tmp, which the host browser cannot read, so xdg-open
+// would silently open nothing. XDG_CACHE_HOME maps to a host-visible path.
 func (us *UIService) ShowAboutPage() error {
 	us.logger.Info("Showing about page...")
-	tmpFile, err := os.CreateTemp("", "dabri-about-*.html")
+	cacheDir, err := os.UserCacheDir()
 	if err != nil {
-		return fmt.Errorf("failed to create temp file: %w", err)
+		cacheDir = os.TempDir()
 	}
-	// Note: temp file for browser access
+	path := filepath.Join(cacheDir, "dabri-about.html")
 	html := strings.Replace(assets.AboutHTML, "{{VERSION}}", appversion.Version, 1)
-	if _, err := tmpFile.WriteString(html); err != nil {
-		return fmt.Errorf("failed to write HTML content: %w", err)
+	if err := os.WriteFile(path, []byte(html), 0o644); err != nil {
+		return fmt.Errorf("failed to write about page: %w", err)
 	}
-	if err := tmpFile.Close(); err != nil {
-		return fmt.Errorf("failed to close temp file: %w", err)
-	}
-	return us.openWithSystem(tmpFile.Name())
+	return us.openWithSystem(path)
 }
 
 // Open configuration file with system default editor

--- a/io.github.ashbuk.dabri.yml
+++ b/io.github.ashbuk.dabri.yml
@@ -55,6 +55,7 @@ modules:
       - --disable-ffplay
       - --disable-ffprobe
       - --disable-network
+      - --enable-libpulse
     cleanup:
       - /share/ffmpeg
     sources:

--- a/io.github.ashbuk.dabri.yml
+++ b/io.github.ashbuk.dabri.yml
@@ -97,6 +97,26 @@ modules:
         url: https://github.com/atx/wtype/archive/refs/tags/v0.4.tar.gz
         sha256: da91786d828b6a6e29b884bc510473939eda052658ebef87d7bdeafa6a8746f9
 
+  # ydotool injects input via /dev/uinput, the only active-window typing path on
+  # wlroots/Hyprland inside the sandbox (wtype's virtual-keyboard protocol is
+  # blocked by the Wayland security-context). The binary is bundled but needs no
+  # device permission by default; users opt in with:
+  #   flatpak override --user --device=all io.github.ashbuk.dabri
+  # On GNOME/KDE the RemoteDesktop portal is used instead (no setup required).
+  - name: ydotool
+    buildsystem: simple
+    build-commands:
+      # Drop manpage (needs scdoc) and the Daemon unit install (absolute SD_UNITDIR
+      # outside /app); the ydotoold binary itself is built at top level.
+      - sed -i '/add_subdirectory(manpage)/d;/add_subdirectory(Daemon)/d' CMakeLists.txt
+      - cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=/app -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      - cmake --build build
+      - cmake --install build
+    sources:
+      - type: archive
+        url: https://github.com/ReimuNotMoe/ydotool/archive/refs/tags/v1.0.4.tar.gz
+        sha256: ba075a43aa6ead51940e892ecffa4d0b8b40c241e4e2bc4bd9bd26b61fde23bd
+
   # SPIRV-Headers cmake config - required by whisper.cpp >= v1.8.5 Vulkan backend
   - name: spirv-headers
     buildsystem: cmake-ninja

--- a/output/factory/factory.go
+++ b/output/factory/factory.go
@@ -164,9 +164,9 @@ func (f *Factory) createClipboardOutputter(env EnvironmentType) (interfaces.Outp
 // extra device permissions. Otherwise it falls back to a CLI tool.
 func (f *Factory) createTypeOutputter(env EnvironmentType) (interfaces.Outputter, error) {
 	if env == EnvironmentWayland && f.config.Output.TypeTool == "auto" && outputters.PortalRemoteDesktopAvailable() {
-		// Best-effort clipboard fallback for characters the portal cannot type (non-ASCII)
-		clip, _ := f.createClipboardOutputter(env)
-		if out, err := outputters.NewPortalOutputter(clip); err == nil {
+		// Text the portal cannot type (non-ASCII) is handled one level up by
+		// IOService, which switches the whole output mode to clipboard.
+		if out, err := outputters.NewPortalOutputter(); err == nil {
 			return out, nil
 		}
 	}

--- a/output/factory/factory.go
+++ b/output/factory/factory.go
@@ -164,7 +164,9 @@ func (f *Factory) createClipboardOutputter(env EnvironmentType) (interfaces.Outp
 // extra device permissions. Otherwise it falls back to a CLI tool.
 func (f *Factory) createTypeOutputter(env EnvironmentType) (interfaces.Outputter, error) {
 	if env == EnvironmentWayland && f.config.Output.TypeTool == "auto" && outputters.PortalRemoteDesktopAvailable() {
-		if out, err := outputters.NewPortalOutputter(); err == nil {
+		// Best-effort clipboard fallback for characters the portal cannot type (non-ASCII)
+		clip, _ := f.createClipboardOutputter(env)
+		if out, err := outputters.NewPortalOutputter(clip); err == nil {
 			return out, nil
 		}
 	}

--- a/output/factory/factory.go
+++ b/output/factory/factory.go
@@ -113,6 +113,11 @@ func (f *Factory) selectGNOMEWaylandTypeTool() string {
 // selectNonGNOMEWaylandTypeTool Non-GNOME Wayland priority chain
 // Priority: wtype (native Wayland) → ydotool → xdotool (XWayland fallback)
 func (f *Factory) selectNonGNOMEWaylandTypeTool() string {
+	// Inside Flatpak the wlroots security-context blocks wtype's virtual-keyboard
+	// protocol, so ydotool (uinput) is the only working CLI path.
+	if platform.IsFlatpak() && f.isToolAvailable("ydotool") {
+		return "ydotool"
+	}
 	if f.isToolAvailable("wtype") {
 		return "wtype"
 	}
@@ -138,22 +143,36 @@ func (f *Factory) selectFallbackTypeTool() string {
 // Security: validates tools via config.IsCommandAllowed before instantiation
 // Returns ClipboardOutputter or TypeOutputter based on config.Output.DefaultMode
 func (f *Factory) GetOutputter(env EnvironmentType) (interfaces.Outputter, error) {
-	clipboardTool := f.selectClipboardTool(env)
-	typeTool := f.selectTypeTool(env)
-	if clipboardTool != "" && !config.IsCommandAllowed(f.config, clipboardTool) {
-		return nil, fmt.Errorf("clipboard tool not allowed: %s", clipboardTool)
+	if f.config.Output.DefaultMode == config.OutputModeActiveWindow {
+		return f.createTypeOutputter(env)
 	}
-	if typeTool != "" && !config.IsCommandAllowed(f.config, typeTool) {
-		return nil, fmt.Errorf("type tool not allowed: %s", typeTool)
+	return f.createClipboardOutputter(env)
+}
+
+// createClipboardOutputter builds a validated clipboard outputter
+func (f *Factory) createClipboardOutputter(env EnvironmentType) (interfaces.Outputter, error) {
+	tool := f.selectClipboardTool(env)
+	if tool != "" && !config.IsCommandAllowed(f.config, tool) {
+		return nil, fmt.Errorf("clipboard tool not allowed: %s", tool)
 	}
-	switch f.config.Output.DefaultMode {
-	case config.OutputModeClipboard:
-		return outputters.NewClipboardOutputter(clipboardTool, f.config)
-	case config.OutputModeActiveWindow:
-		return outputters.NewTypeOutputter(typeTool, f.config)
-	default:
-		return outputters.NewClipboardOutputter(clipboardTool, f.config)
+	return outputters.NewClipboardOutputter(tool, f.config)
+}
+
+// createTypeOutputter builds a validated active-window outputter.
+// Prefers the RemoteDesktop portal on Wayland (GNOME/KDE) when the typing tool is
+// auto-selected: it is the only path that works inside a Flatpak sandbox without
+// extra device permissions. Otherwise it falls back to a CLI tool.
+func (f *Factory) createTypeOutputter(env EnvironmentType) (interfaces.Outputter, error) {
+	if env == EnvironmentWayland && f.config.Output.TypeTool == "auto" && outputters.PortalRemoteDesktopAvailable() {
+		if out, err := outputters.NewPortalOutputter(f.config); err == nil {
+			return out, nil
+		}
 	}
+	tool := f.selectTypeTool(env)
+	if tool != "" && !config.IsCommandAllowed(f.config, tool) {
+		return nil, fmt.Errorf("type tool not allowed: %s", tool)
+	}
+	return outputters.NewTypeOutputter(tool, f.config)
 }
 
 // Create an outputter directly from a configuration

--- a/output/factory/factory.go
+++ b/output/factory/factory.go
@@ -164,7 +164,7 @@ func (f *Factory) createClipboardOutputter(env EnvironmentType) (interfaces.Outp
 // extra device permissions. Otherwise it falls back to a CLI tool.
 func (f *Factory) createTypeOutputter(env EnvironmentType) (interfaces.Outputter, error) {
 	if env == EnvironmentWayland && f.config.Output.TypeTool == "auto" && outputters.PortalRemoteDesktopAvailable() {
-		if out, err := outputters.NewPortalOutputter(f.config); err == nil {
+		if out, err := outputters.NewPortalOutputter(); err == nil {
 			return out, nil
 		}
 	}

--- a/output/outputters/input_daemon.go
+++ b/output/outputters/input_daemon.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
+package outputters
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// YdotoolDaemon owns a ydotoold process. Inside Flatpak on wlroots/Hyprland the
+// host daemon's socket is not visible to the sandbox, so the client needs its own.
+type YdotoolDaemon struct {
+	cmd *exec.Cmd
+}
+
+// StartYdotoolDaemon launches ydotoold and exports YDOTOOL_SOCKET for the client.
+// Returns nil when uinput is inaccessible (no --device=all / udev rule) or the
+// daemon binary is missing, so callers transparently fall back to clipboard.
+func StartYdotoolDaemon() *YdotoolDaemon {
+	if !UinputWritable() {
+		return nil
+	}
+	bin, err := exec.LookPath("ydotoold")
+	if err != nil {
+		return nil
+	}
+	socket := filepath.Join(runtimeDir(), ".ydotool_socket")
+	_ = os.Setenv("YDOTOOL_SOCKET", socket)
+
+	// #nosec G204 -- fixed binary resolved from PATH, no user-controlled input
+	cmd := exec.Command(bin, "-p", socket, "-P", "0600")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		return nil
+	}
+	waitForSocket(socket, 2*time.Second)
+	return &YdotoolDaemon{cmd: cmd}
+}
+
+// Stop terminates the daemon
+func (d *YdotoolDaemon) Stop() {
+	if d == nil || d.cmd == nil || d.cmd.Process == nil {
+		return
+	}
+	_ = d.cmd.Process.Kill()
+	_ = d.cmd.Wait()
+}
+
+// UinputWritable reports whether /dev/uinput can be opened for writing
+func UinputWritable() bool {
+	f, err := os.OpenFile("/dev/uinput", os.O_WRONLY, 0)
+	if err != nil {
+		return false
+	}
+	_ = f.Close()
+	return true
+}
+
+func runtimeDir() string {
+	if d := os.Getenv("XDG_RUNTIME_DIR"); d != "" {
+		return d
+	}
+	return os.TempDir()
+}
+
+func waitForSocket(path string, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/output/outputters/portal_outputter.go
+++ b/output/outputters/portal_outputter.go
@@ -1,0 +1,245 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
+package outputters
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+
+	"github.com/AshBuk/dabri/v2/config"
+	"github.com/AshBuk/dabri/v2/output/interfaces"
+)
+
+// RemoteDesktop portal — the sandbox-clean typing path. Input is injected by the
+// compositor itself, so the Flatpak security-context that blocks wtype does not
+// apply. Available on GNOME/KDE; the wlroots/Hyprland portal does not implement it.
+const (
+	portalDest      = "org.freedesktop.portal.Desktop"
+	portalPath      = "/org/freedesktop/portal/desktop"
+	portalRemote    = "org.freedesktop.portal.RemoteDesktop"
+	portalRequest   = "org.freedesktop.portal.Request"
+	rdKeyboard      = uint32(1) // RemoteDesktop DeviceType bitmask: KEYBOARD
+	rdPersistToken  = uint32(2) // persist_mode: keep permission across restarts
+	keyReleased     = uint32(0)
+	keyPressed      = uint32(1)
+	portalCallReply = 60 * time.Second
+)
+
+var portalTokenSeq uint64
+
+// PortalRemoteDesktopAvailable reports whether the RemoteDesktop portal exposes
+// keyboard injection on the current session.
+func PortalRemoteDesktopAvailable() bool {
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		return false
+	}
+	var v dbus.Variant
+	if err := conn.Object(portalDest, portalPath).
+		Call("org.freedesktop.DBus.Properties.Get", 0, portalRemote, "AvailableDeviceTypes").
+		Store(&v); err != nil {
+		return false
+	}
+	types, ok := v.Value().(uint32)
+	return ok && types&rdKeyboard != 0
+}
+
+// PortalOutputter types text through the RemoteDesktop portal
+type PortalOutputter struct {
+	config    *config.Config
+	tokenPath string
+
+	mu      sync.Mutex
+	conn    *dbus.Conn
+	signals chan *dbus.Signal
+	session dbus.ObjectPath
+}
+
+// NewPortalOutputter creates a portal-based type outputter (session is opened lazily)
+func NewPortalOutputter(cfg *config.Config) (interfaces.Outputter, error) {
+	if !PortalRemoteDesktopAvailable() {
+		return nil, fmt.Errorf("RemoteDesktop portal not available")
+	}
+	return &PortalOutputter{config: cfg, tokenPath: portalTokenPath()}, nil
+}
+
+// TypeToActiveWindow injects text as keyboard input into the focused window
+func (p *PortalOutputter) TypeToActiveWindow(text string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := p.ensureSession(); err != nil {
+		return fmt.Errorf("portal session: %w", err)
+	}
+	obj := p.conn.Object(portalDest, portalPath)
+	opts := map[string]dbus.Variant{}
+	for _, r := range text {
+		keysym := int32(runeToKeysym(r))
+		for _, state := range [2]uint32{keyPressed, keyReleased} {
+			if call := obj.Call(portalRemote+".NotifyKeyboardKeysym", 0, p.session, opts, keysym, state); call.Err != nil {
+				return fmt.Errorf("notify keysym: %w", call.Err)
+			}
+		}
+	}
+	return nil
+}
+
+// CopyToClipboard is not supported by this outputter
+func (p *PortalOutputter) CopyToClipboard(text string) error {
+	return fmt.Errorf("copying to clipboard not supported by portal outputter")
+}
+
+// GetToolNames reports the active typing backend
+func (p *PortalOutputter) GetToolNames() (clipboardTool, typeTool string) {
+	return "", "portal"
+}
+
+// ensureSession lazily creates and starts the RemoteDesktop keyboard session.
+// A dedicated connection is kept open because the session lives with it.
+func (p *PortalOutputter) ensureSession() error {
+	if p.session != "" {
+		return nil
+	}
+	conn, err := dbus.ConnectSessionBus()
+	if err != nil {
+		return fmt.Errorf("connect session bus: %w", err)
+	}
+	p.conn = conn
+	p.signals = make(chan *dbus.Signal, 8)
+	conn.Signal(p.signals)
+
+	created, err := p.request("CreateSession", func(token string) []interface{} {
+		return []interface{}{map[string]dbus.Variant{
+			"handle_token":         dbus.MakeVariant(token),
+			"session_handle_token": dbus.MakeVariant(token),
+		}}
+	})
+	if err != nil {
+		return err
+	}
+	handle, _ := created["session_handle"].Value().(string)
+	if handle == "" {
+		return fmt.Errorf("empty session handle")
+	}
+	session := dbus.ObjectPath(handle)
+
+	if _, err := p.request("SelectDevices", func(token string) []interface{} {
+		opts := map[string]dbus.Variant{
+			"handle_token": dbus.MakeVariant(token),
+			"types":        dbus.MakeVariant(rdKeyboard),
+			"persist_mode": dbus.MakeVariant(rdPersistToken),
+		}
+		if t := p.loadToken(); t != "" {
+			opts["restore_token"] = dbus.MakeVariant(t)
+		}
+		return []interface{}{session, opts}
+	}); err != nil {
+		return err
+	}
+
+	started, err := p.request("Start", func(token string) []interface{} {
+		return []interface{}{session, "", map[string]dbus.Variant{
+			"handle_token": dbus.MakeVariant(token),
+		}}
+	})
+	if err != nil {
+		return err
+	}
+	if t, ok := started["restore_token"].Value().(string); ok {
+		p.saveToken(t)
+	}
+	p.session = session
+	return nil
+}
+
+// request invokes a portal method and waits for its asynchronous Response signal
+func (p *PortalOutputter) request(method string, build func(token string) []interface{}) (map[string]dbus.Variant, error) {
+	token := fmt.Sprintf("dabri%d", atomic.AddUint64(&portalTokenSeq, 1))
+	sender := strings.ReplaceAll(strings.TrimPrefix(p.conn.Names()[0], ":"), ".", "_")
+	reqPath := dbus.ObjectPath("/org/freedesktop/portal/desktop/request/" + sender + "/" + token)
+
+	match := []dbus.MatchOption{
+		dbus.WithMatchObjectPath(reqPath),
+		dbus.WithMatchInterface(portalRequest),
+		dbus.WithMatchMember("Response"),
+	}
+	if err := p.conn.AddMatchSignal(match...); err != nil {
+		return nil, err
+	}
+	defer func() { _ = p.conn.RemoveMatchSignal(match...) }()
+
+	var handle dbus.ObjectPath
+	if err := p.conn.Object(portalDest, portalPath).
+		Call(portalRemote+"."+method, 0, build(token)...).Store(&handle); err != nil {
+		return nil, fmt.Errorf("%s: %w", method, err)
+	}
+
+	timeout := time.After(portalCallReply)
+	for {
+		select {
+		case sig := <-p.signals:
+			if sig == nil || sig.Path != reqPath || sig.Name != portalRequest+".Response" {
+				continue
+			}
+			var code uint32
+			var results map[string]dbus.Variant
+			if err := dbus.Store(sig.Body, &code, &results); err != nil {
+				return nil, fmt.Errorf("%s response: %w", method, err)
+			}
+			if code != 0 {
+				return nil, fmt.Errorf("%s rejected (code %d)", method, code)
+			}
+			return results, nil
+		case <-timeout:
+			return nil, fmt.Errorf("%s timed out", method)
+		}
+	}
+}
+
+// runeToKeysym maps a rune to an X11 keysym. Latin-1 maps 1:1; other code points
+// use the Unicode keysym range so non-ASCII transcripts still type.
+func runeToKeysym(r rune) rune {
+	switch r {
+	case '\n':
+		return 0xff0d // Return
+	case '\t':
+		return 0xff09 // Tab
+	case '\b':
+		return 0xff08 // BackSpace
+	}
+	if r <= 0x7e || (r >= 0xa0 && r <= 0xff) {
+		return r
+	}
+	return 0x01000000 + r
+}
+
+func portalTokenPath() string {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, "dabri", "portal-remotedesktop.token")
+}
+
+func (p *PortalOutputter) loadToken() string {
+	if p.tokenPath == "" {
+		return ""
+	}
+	b, _ := os.ReadFile(p.tokenPath)
+	return strings.TrimSpace(string(b))
+}
+
+func (p *PortalOutputter) saveToken(token string) {
+	if p.tokenPath == "" || token == "" {
+		return
+	}
+	_ = os.MkdirAll(filepath.Dir(p.tokenPath), 0o700)
+	_ = os.WriteFile(p.tokenPath, []byte(token), 0o600)
+}

--- a/output/outputters/portal_outputter.go
+++ b/output/outputters/portal_outputter.go
@@ -7,237 +7,54 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
-	"sync"
-	"sync/atomic"
-	"time"
 
-	"github.com/godbus/dbus/v5"
+	"github.com/AshBuk/go-wlportal/remotedesktop"
 
 	"github.com/AshBuk/dabri/v2/output/interfaces"
 )
 
-// RemoteDesktop portal — the sandbox-clean typing path. Input is injected by the
-// compositor itself, so the Flatpak security-context that blocks wtype does not
-// apply. Available on GNOME/KDE; the wlroots/Hyprland portal does not implement it.
-const (
-	portalDest      = "org.freedesktop.portal.Desktop"
-	portalPath      = "/org/freedesktop/portal/desktop"
-	portalRemote    = "org.freedesktop.portal.RemoteDesktop"
-	portalRequest   = "org.freedesktop.portal.Request"
-	rdKeyboard      = uint32(1) // RemoteDesktop DeviceType bitmask: KEYBOARD
-	rdPersistToken  = uint32(2) // persist_mode: keep permission across restarts
-	keyReleased     = uint32(0)
-	keyPressed      = uint32(1)
-	portalCallReply = 60 * time.Second
-)
-
-var portalTokenSeq uint64
-
 // PortalRemoteDesktopAvailable reports whether the RemoteDesktop portal exposes
-// keyboard injection on the current session.
+// keyboard injection. This is the sandbox-clean typing path on GNOME/KDE; the
+// wlroots/Hyprland portal does not implement it.
 func PortalRemoteDesktopAvailable() bool {
-	conn, err := dbus.SessionBus()
-	if err != nil {
-		return false
-	}
-	var v dbus.Variant
-	if err := conn.Object(portalDest, portalPath).
-		Call("org.freedesktop.DBus.Properties.Get", 0, portalRemote, "AvailableDeviceTypes").
-		Store(&v); err != nil {
-		return false
-	}
-	types, ok := v.Value().(uint32)
-	return ok && types&rdKeyboard != 0
+	return remotedesktop.Available()
 }
 
-// PortalOutputter types text through the RemoteDesktop portal
+// PortalOutputter types text through the RemoteDesktop portal (go-wlportal)
 type PortalOutputter struct {
-	tokenPath string
-
-	mu      sync.Mutex
-	conn    *dbus.Conn
-	signals chan *dbus.Signal
-	session dbus.ObjectPath
+	kbd *remotedesktop.Keyboard
 }
 
 // NewPortalOutputter creates a portal-based type outputter (session is opened lazily)
 func NewPortalOutputter() (interfaces.Outputter, error) {
-	if !PortalRemoteDesktopAvailable() {
-		return nil, fmt.Errorf("RemoteDesktop portal not available")
+	kbd, err := remotedesktop.NewKeyboard(remotedesktop.WithRestoreTokenPath(portalTokenPath()))
+	if err != nil {
+		return nil, err
 	}
-	return &PortalOutputter{tokenPath: portalTokenPath()}, nil
+	return &PortalOutputter{kbd: kbd}, nil
 }
 
 // TypeToActiveWindow injects text as keyboard input into the focused window
-func (p *PortalOutputter) TypeToActiveWindow(text string) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if err := p.ensureSession(); err != nil {
-		return fmt.Errorf("portal session: %w", err)
-	}
-	obj := p.conn.Object(portalDest, portalPath)
-	opts := map[string]dbus.Variant{}
-	for _, r := range text {
-		keysym := int32(runeToKeysym(r))
-		for _, state := range [2]uint32{keyPressed, keyReleased} {
-			if call := obj.Call(portalRemote+".NotifyKeyboardKeysym", 0, p.session, opts, keysym, state); call.Err != nil {
-				return fmt.Errorf("notify keysym: %w", call.Err)
-			}
-		}
-	}
-	return nil
+func (o *PortalOutputter) TypeToActiveWindow(text string) error {
+	return o.kbd.Type(text)
 }
 
 // CopyToClipboard is not supported by this outputter
-func (p *PortalOutputter) CopyToClipboard(text string) error {
+func (o *PortalOutputter) CopyToClipboard(text string) error {
 	return fmt.Errorf("copying to clipboard not supported by portal outputter")
 }
 
 // GetToolNames reports the active typing backend
-func (p *PortalOutputter) GetToolNames() (clipboardTool, typeTool string) {
+func (o *PortalOutputter) GetToolNames() (clipboardTool, typeTool string) {
 	return "", "portal"
 }
 
-// ensureSession lazily creates and starts the RemoteDesktop keyboard session.
-// A dedicated connection is kept open because the session lives with it.
-func (p *PortalOutputter) ensureSession() error {
-	if p.session != "" {
-		return nil
-	}
-	conn, err := dbus.ConnectSessionBus()
-	if err != nil {
-		return fmt.Errorf("connect session bus: %w", err)
-	}
-	p.conn = conn
-	p.signals = make(chan *dbus.Signal, 8)
-	conn.Signal(p.signals)
-
-	created, err := p.request("CreateSession", func(token string) []interface{} {
-		return []interface{}{map[string]dbus.Variant{
-			"handle_token":         dbus.MakeVariant(token),
-			"session_handle_token": dbus.MakeVariant(token),
-		}}
-	})
-	if err != nil {
-		return err
-	}
-	handle, _ := created["session_handle"].Value().(string)
-	if handle == "" {
-		return fmt.Errorf("empty session handle")
-	}
-	session := dbus.ObjectPath(handle)
-
-	if _, err := p.request("SelectDevices", func(token string) []interface{} {
-		opts := map[string]dbus.Variant{
-			"handle_token": dbus.MakeVariant(token),
-			"types":        dbus.MakeVariant(rdKeyboard),
-			"persist_mode": dbus.MakeVariant(rdPersistToken),
-		}
-		if t := p.loadToken(); t != "" {
-			opts["restore_token"] = dbus.MakeVariant(t)
-		}
-		return []interface{}{session, opts}
-	}); err != nil {
-		return err
-	}
-
-	started, err := p.request("Start", func(token string) []interface{} {
-		return []interface{}{session, "", map[string]dbus.Variant{
-			"handle_token": dbus.MakeVariant(token),
-		}}
-	})
-	if err != nil {
-		return err
-	}
-	if t, ok := started["restore_token"].Value().(string); ok {
-		p.saveToken(t)
-	}
-	p.session = session
-	return nil
-}
-
-// request invokes a portal method and waits for its asynchronous Response signal
-func (p *PortalOutputter) request(method string, build func(token string) []interface{}) (map[string]dbus.Variant, error) {
-	token := fmt.Sprintf("dabri%d", atomic.AddUint64(&portalTokenSeq, 1))
-	sender := strings.ReplaceAll(strings.TrimPrefix(p.conn.Names()[0], ":"), ".", "_")
-	reqPath := dbus.ObjectPath("/org/freedesktop/portal/desktop/request/" + sender + "/" + token)
-
-	match := []dbus.MatchOption{
-		dbus.WithMatchObjectPath(reqPath),
-		dbus.WithMatchInterface(portalRequest),
-		dbus.WithMatchMember("Response"),
-	}
-	if err := p.conn.AddMatchSignal(match...); err != nil {
-		return nil, err
-	}
-	defer func() { _ = p.conn.RemoveMatchSignal(match...) }()
-
-	var handle dbus.ObjectPath
-	if err := p.conn.Object(portalDest, portalPath).
-		Call(portalRemote+"."+method, 0, build(token)...).Store(&handle); err != nil {
-		return nil, fmt.Errorf("%s: %w", method, err)
-	}
-
-	timeout := time.After(portalCallReply)
-	for {
-		select {
-		case sig := <-p.signals:
-			if sig == nil || sig.Path != reqPath || sig.Name != portalRequest+".Response" {
-				continue
-			}
-			var code uint32
-			var results map[string]dbus.Variant
-			if err := dbus.Store(sig.Body, &code, &results); err != nil {
-				return nil, fmt.Errorf("%s response: %w", method, err)
-			}
-			if code != 0 {
-				return nil, fmt.Errorf("%s rejected (code %d)", method, code)
-			}
-			return results, nil
-		case <-timeout:
-			return nil, fmt.Errorf("%s timed out", method)
-		}
-	}
-}
-
-// runeToKeysym maps a rune to an X11 keysym. Latin-1 maps 1:1; other code points
-// use the Unicode keysym range so non-ASCII transcripts still type.
-func runeToKeysym(r rune) rune {
-	switch r {
-	case '\n':
-		return 0xff0d // Return
-	case '\t':
-		return 0xff09 // Tab
-	case '\b':
-		return 0xff08 // BackSpace
-	}
-	if r <= 0x7e || (r >= 0xa0 && r <= 0xff) {
-		return r
-	}
-	return 0x01000000 + r
-}
-
+// portalTokenPath returns where the portal permission token is persisted so the
+// consent dialog appears only once across restarts.
 func portalTokenPath() string {
 	dir, err := os.UserConfigDir()
 	if err != nil {
 		return ""
 	}
 	return filepath.Join(dir, "dabri", "portal-remotedesktop.token")
-}
-
-func (p *PortalOutputter) loadToken() string {
-	if p.tokenPath == "" {
-		return ""
-	}
-	b, _ := os.ReadFile(p.tokenPath)
-	return strings.TrimSpace(string(b))
-}
-
-func (p *PortalOutputter) saveToken(token string) {
-	if p.tokenPath == "" || token == "" {
-		return
-	}
-	_ = os.MkdirAll(filepath.Dir(p.tokenPath), 0o700)
-	_ = os.WriteFile(p.tokenPath, []byte(token), 0o600)
 }

--- a/output/outputters/portal_outputter.go
+++ b/output/outputters/portal_outputter.go
@@ -23,19 +23,29 @@ func PortalRemoteDesktopAvailable() bool {
 // PortalOutputter types text through the RemoteDesktop portal (go-wlportal)
 type PortalOutputter struct {
 	kbd *remotedesktop.Keyboard
+	// clipboard handles text the portal cannot type (non-ASCII), nil disables fallback
+	clipboard interfaces.Outputter
 }
 
-// NewPortalOutputter creates a portal-based type outputter (session is opened lazily)
-func NewPortalOutputter() (interfaces.Outputter, error) {
+// NewPortalOutputter creates a portal-based type outputter (session is opened lazily).
+// clipboard is an optional fallback used for characters the portal cannot inject.
+func NewPortalOutputter(clipboard interfaces.Outputter) (interfaces.Outputter, error) {
 	kbd, err := remotedesktop.NewKeyboard(remotedesktop.WithRestoreTokenPath(portalTokenPath()))
 	if err != nil {
 		return nil, err
 	}
-	return &PortalOutputter{kbd: kbd}, nil
+	return &PortalOutputter{kbd: kbd, clipboard: clipboard}, nil
 }
 
-// TypeToActiveWindow injects text as keyboard input into the focused window
+// TypeToActiveWindow injects text as keyboard input into the focused window.
+// The RemoteDesktop portal maps keysyms through the compositor's active layout,
+// so characters outside it (e.g. Cyrillic on a Latin layout) are silently dropped.
+// Such non-ASCII text is routed to the clipboard so nothing is lost; the typing
+// mode itself is preserved, so subsequent ASCII text keeps typing.
 func (o *PortalOutputter) TypeToActiveWindow(text string) error {
+	if o.clipboard != nil && isNonASCII(text) {
+		return o.clipboard.CopyToClipboard(text)
+	}
 	return o.kbd.Type(text)
 }
 

--- a/output/outputters/portal_outputter.go
+++ b/output/outputters/portal_outputter.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/godbus/dbus/v5"
 
-	"github.com/AshBuk/dabri/v2/config"
 	"github.com/AshBuk/dabri/v2/output/interfaces"
 )
 
@@ -54,7 +53,6 @@ func PortalRemoteDesktopAvailable() bool {
 
 // PortalOutputter types text through the RemoteDesktop portal
 type PortalOutputter struct {
-	config    *config.Config
 	tokenPath string
 
 	mu      sync.Mutex
@@ -64,11 +62,11 @@ type PortalOutputter struct {
 }
 
 // NewPortalOutputter creates a portal-based type outputter (session is opened lazily)
-func NewPortalOutputter(cfg *config.Config) (interfaces.Outputter, error) {
+func NewPortalOutputter() (interfaces.Outputter, error) {
 	if !PortalRemoteDesktopAvailable() {
 		return nil, fmt.Errorf("RemoteDesktop portal not available")
 	}
-	return &PortalOutputter{config: cfg, tokenPath: portalTokenPath()}, nil
+	return &PortalOutputter{tokenPath: portalTokenPath()}, nil
 }
 
 // TypeToActiveWindow injects text as keyboard input into the focused window

--- a/output/outputters/portal_outputter.go
+++ b/output/outputters/portal_outputter.go
@@ -23,28 +23,25 @@ func PortalRemoteDesktopAvailable() bool {
 // types text through the RemoteDesktop portal via the go-wlportal/typing adapter
 type PortalOutputter struct {
 	kbd *typing.Keyboard
-	// clipboard handles text the portal cannot type (non-ASCII), nil disables fallback
-	clipboard interfaces.Outputter
 }
 
 // NewPortalOutputter creates a portal-based type outputter (session is opened lazily).
-// clipboard is an optional fallback used for characters the portal cannot inject.
-func NewPortalOutputter(clipboard interfaces.Outputter) (interfaces.Outputter, error) {
+func NewPortalOutputter() (interfaces.Outputter, error) {
 	kbd, err := typing.NewKeyboard(typing.WithRestoreTokenPath(portalTokenPath()))
 	if err != nil {
 		return nil, err
 	}
-	return &PortalOutputter{kbd: kbd, clipboard: clipboard}, nil
+	return &PortalOutputter{kbd: kbd}, nil
 }
 
 // TypeToActiveWindow injects text as keyboard input into the focused window.
 // The RemoteDesktop portal maps keysyms through the compositor's active layout,
 // so characters outside it (e.g. Cyrillic on a Latin layout) are silently dropped.
-// Such non-ASCII text is routed to the clipboard so nothing is lost; the typing
-// mode itself is preserved, so subsequent ASCII text keeps typing.
+// Rather than lose such text, we report an error so IOService switches the whole
+// output mode to clipboard — honest behaviour the user is notified about.
 func (o *PortalOutputter) TypeToActiveWindow(text string) error {
-	if o.clipboard != nil && isNonASCII(text) {
-		return o.clipboard.CopyToClipboard(text)
+	if isNonASCII(text) {
+		return fmt.Errorf("portal cannot type non-ASCII text through the active keyboard layout")
 	}
 	return o.kbd.Type(text)
 }

--- a/output/outputters/portal_outputter.go
+++ b/output/outputters/portal_outputter.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/AshBuk/go-wlportal/remotedesktop"
+	"github.com/AshBuk/go-wlportal/typing"
 
 	"github.com/AshBuk/dabri/v2/output/interfaces"
 )
@@ -17,12 +17,12 @@ import (
 // keyboard injection. This is the sandbox-clean typing path on GNOME/KDE; the
 // wlroots/Hyprland portal does not implement it.
 func PortalRemoteDesktopAvailable() bool {
-	return remotedesktop.Available()
+	return typing.Available()
 }
 
-// PortalOutputter types text through the RemoteDesktop portal (go-wlportal)
+// types text through the RemoteDesktop portal via the go-wlportal/typing adapter
 type PortalOutputter struct {
-	kbd *remotedesktop.Keyboard
+	kbd *typing.Keyboard
 	// clipboard handles text the portal cannot type (non-ASCII), nil disables fallback
 	clipboard interfaces.Outputter
 }
@@ -30,7 +30,7 @@ type PortalOutputter struct {
 // NewPortalOutputter creates a portal-based type outputter (session is opened lazily).
 // clipboard is an optional fallback used for characters the portal cannot inject.
 func NewPortalOutputter(clipboard interfaces.Outputter) (interfaces.Outputter, error) {
-	kbd, err := remotedesktop.NewKeyboard(remotedesktop.WithRestoreTokenPath(portalTokenPath()))
+	kbd, err := typing.NewKeyboard(typing.WithRestoreTokenPath(portalTokenPath()))
 	if err != nil {
 		return nil, err
 	}

--- a/packaging/flatpak/arecord
+++ b/packaging/flatpak/arecord
@@ -53,10 +53,11 @@ fi
 # pulseaudio socket is granted directly by --socket=pulseaudio, so "default"
 # resolves to the default PipeWire/PulseAudio source.
 #
-# -flush_packets 1 keeps captured audio on disk continuously: dabri stops
-# recording with a signal and this ffmpeg does not finalize the WAV on signal,
-# so its output buffer would otherwise be lost.
-set -- ffmpeg -nostdin -hide_banner -loglevel error -y \
+# Dabri stops recording by writing "q" to ffmpeg's stdin (BaseRecorder graceful
+# stop), so ffmpeg finalizes the WAV header itself — no kill/re-mux needed. We
+# exec ffmpeg directly so it inherits that stdin and replaces this shell.
+# -flush_packets 1 keeps captured audio flushed to disk while recording.
+set -- ffmpeg -hide_banner -loglevel error -y \
     -f pulse -i "$device" \
     -ac "$channels" -ar "$rate" \
     -c:a pcm_s16le -flush_packets 1 -f wav
@@ -65,26 +66,4 @@ if [ -n "$duration" ]; then
     set -- "$@" -t "$duration"
 fi
 
-# Stream mode (stdout): nothing to finalize, exec directly.
-if [ "$output" = "-" ]; then
-    exec "$@" -
-fi
-
-# File mode: run ffmpeg as a child so we can finalize on stop. Because this
-# ffmpeg leaves placeholder (0xFFFFFFFF) WAV sizes when killed, re-mux the
-# captured file with "-c copy" to rewrite a correct, decodable header.
-"$@" "$output" &
-ff=$!
-
-finalize() {
-    kill -KILL "$ff" 2>/dev/null || true
-    wait "$ff" 2>/dev/null || true
-    if ffmpeg -nostdin -hide_banner -loglevel error -y -i "$output" -c copy -f wav "$output.tmp" 2>/dev/null; then
-        mv -f "$output.tmp" "$output"
-    fi
-    exit 0
-}
-
-trap finalize INT TERM
-wait "$ff" || true
-finalize
+exec "$@" "$output"

--- a/packaging/flatpak/arecord
+++ b/packaging/flatpak/arecord
@@ -43,6 +43,9 @@ if [ -z "$output" ]; then
     output="-"
 fi
 
+# Capture via the pulse indev (ffmpeg built with --enable-libpulse). The
+# pulseaudio socket is granted directly by --socket=pulseaudio, so "default"
+# resolves to the default PipeWire/PulseAudio source.
 set -- ffmpeg -nostdin -hide_banner -loglevel error -y \
     -f pulse -i "$device" \
     -ac "$channels" -ar "$rate" \

--- a/packaging/flatpak/arecord
+++ b/packaging/flatpak/arecord
@@ -29,6 +29,12 @@ while [ "$#" -gt 0 ]; do
         -f|-t)
             shift 2
             ;;
+        -l|-L|--list-devices|--list-pcms|--version)
+            # Query flags (used by audio diagnostics). The ffmpeg/pulse backend
+            # has no ALSA device enumeration, so just succeed without recording;
+            # otherwise the default capture branch below would record forever.
+            exit 0
+            ;;
         -*)
             shift
             ;;
@@ -46,13 +52,39 @@ fi
 # Capture via the pulse indev (ffmpeg built with --enable-libpulse). The
 # pulseaudio socket is granted directly by --socket=pulseaudio, so "default"
 # resolves to the default PipeWire/PulseAudio source.
+#
+# -flush_packets 1 keeps captured audio on disk continuously: dabri stops
+# recording with a signal and this ffmpeg does not finalize the WAV on signal,
+# so its output buffer would otherwise be lost.
 set -- ffmpeg -nostdin -hide_banner -loglevel error -y \
     -f pulse -i "$device" \
     -ac "$channels" -ar "$rate" \
-    -c:a pcm_s16le -f wav
+    -c:a pcm_s16le -flush_packets 1 -f wav
 
 if [ -n "$duration" ]; then
     set -- "$@" -t "$duration"
 fi
 
-exec "$@" "$output"
+# Stream mode (stdout): nothing to finalize, exec directly.
+if [ "$output" = "-" ]; then
+    exec "$@" -
+fi
+
+# File mode: run ffmpeg as a child so we can finalize on stop. Because this
+# ffmpeg leaves placeholder (0xFFFFFFFF) WAV sizes when killed, re-mux the
+# captured file with "-c copy" to rewrite a correct, decodable header.
+"$@" "$output" &
+ff=$!
+
+finalize() {
+    kill -KILL "$ff" 2>/dev/null || true
+    wait "$ff" 2>/dev/null || true
+    if ffmpeg -nostdin -hide_banner -loglevel error -y -i "$output" -c copy -f wav "$output.tmp" 2>/dev/null; then
+        mv -f "$output.tmp" "$output"
+    fi
+    exit 0
+}
+
+trap finalize INT TERM
+wait "$ff" || true
+finalize

--- a/packaging/flatpak/go.mod.yml
+++ b/packaging/flatpak/go.mod.yml
@@ -18,10 +18,10 @@
   type: archive
   url: https://proxy.golang.org/gopkg.in/yaml.v2/@v/v2.4.0.zip
 - dest: vendor/github.com/AshBuk/go-wlportal
-  sha256: 5bac99cfeb5709adcedf69e74a5c1dfd95d0eb754f13a94699d412414fe45f81
+  sha256: def7a1706beabddebc18ecc7ae44159106307efddd396c390a93636f2e53a64d
   strip-components: 3
   type: archive
-  url: https://proxy.golang.org/github.com/!ash!buk/go-wlportal/@v/v0.1.0.zip
+  url: https://proxy.golang.org/github.com/!ash!buk/go-wlportal/@v/v0.2.0.zip
 - dest: vendor/github.com/ggerganov/whisper.cpp/bindings/go
   sha256: 9b080f427c529cd7d4ce4b80734aed33c4cc72d7c7ba7cc7e9c8a53464f38b65
   strip-components: 5

--- a/packaging/flatpak/go.mod.yml
+++ b/packaging/flatpak/go.mod.yml
@@ -17,6 +17,11 @@
   strip-components: 2
   type: archive
   url: https://proxy.golang.org/gopkg.in/yaml.v2/@v/v2.4.0.zip
+- dest: vendor/github.com/AshBuk/go-wlportal
+  sha256: 5bac99cfeb5709adcedf69e74a5c1dfd95d0eb754f13a94699d412414fe45f81
+  strip-components: 3
+  type: archive
+  url: https://proxy.golang.org/github.com/!ash!buk/go-wlportal/@v/v0.1.0.zip
 - dest: vendor/github.com/ggerganov/whisper.cpp/bindings/go
   sha256: 9b080f427c529cd7d4ce4b80734aed33c4cc72d7c7ba7cc7e9c8a53464f38b65
   strip-components: 5

--- a/packaging/flatpak/modules.txt
+++ b/packaging/flatpak/modules.txt
@@ -3,9 +3,11 @@
 fyne.io/systray
 fyne.io/systray/internal/generated/menu
 fyne.io/systray/internal/generated/notifier
-# github.com/AshBuk/go-wlportal v0.1.0
+# github.com/AshBuk/go-wlportal v0.2.0
 ## explicit; go 1.25.0
-github.com/AshBuk/go-wlportal/remotedesktop
+github.com/AshBuk/go-wlportal/internal/portal
+github.com/AshBuk/go-wlportal/shortcuts
+github.com/AshBuk/go-wlportal/typing
 # github.com/ggerganov/whisper.cpp/bindings/go v0.0.0-20260601115620-23ee03506a91
 ## explicit; go 1.23
 github.com/ggerganov/whisper.cpp/bindings/go

--- a/packaging/flatpak/modules.txt
+++ b/packaging/flatpak/modules.txt
@@ -3,6 +3,9 @@
 fyne.io/systray
 fyne.io/systray/internal/generated/menu
 fyne.io/systray/internal/generated/notifier
+# github.com/AshBuk/go-wlportal v0.1.0
+## explicit; go 1.25.0
+github.com/AshBuk/go-wlportal/remotedesktop
 # github.com/ggerganov/whisper.cpp/bindings/go v0.0.0-20260601115620-23ee03506a91
 ## explicit; go 1.23
 github.com/ggerganov/whisper.cpp/bindings/go

--- a/tests/integration/platform_integration_test.go
+++ b/tests/integration/platform_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/AshBuk/dabri/v2/config"
 	"github.com/AshBuk/dabri/v2/hotkeys/providers"
@@ -170,9 +171,14 @@ func TestModelAvailability(t *testing.T) {
 		cfg := &config.Config{}
 		config.SetDefaultConfig(cfg)
 
-		// Test ModelManager's bundled model path resolution
+		// Test ModelManager's bundled model path resolution.
+		// Use a short timeout: when no bundled model exists (development), GetModelPath
+		// falls through to a network download — without a deadline this test would block
+		// downloading the full model. The timeout makes the missing-model case fail fast.
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
 		modelManager := whisper.NewModelManager(cfg)
-		modelPath, err := modelManager.GetModelPath(context.Background())
+		modelPath, err := modelManager.GetModelPath(ctx)
 		if err != nil {
 			t.Logf("Bundled model not found (expected for development): %v", err)
 		} else {

--- a/whisper/engine.go
+++ b/whisper/engine.go
@@ -98,6 +98,11 @@ func (w *WhisperEngine) Transcribe(audioFile string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to load audio data: %w", err)
 	}
+	// Guard against empty input: whisper.cpp bindings panic on a zero-length
+	// sample slice (index out of range).
+	if len(audioData) == 0 {
+		return "", fmt.Errorf("no audio samples decoded from %s", audioFile)
+	}
 	context, err := w.model.NewContext()
 	if err != nil {
 		return "", fmt.Errorf("failed to create whisper context: %w", err)

--- a/whisper/providers/model_downloader.go
+++ b/whisper/providers/model_downloader.go
@@ -7,10 +7,24 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 )
+
+// httpClient is used for model downloads. It sets connection-establishment and
+// response-header timeouts so a stalled server fails fast, but deliberately has
+// no total Timeout: model files are large and may legitimately take a while on
+// slow links. Total cancellation is handled via the request context.
+var httpClient = &http.Client{
+	Transport: &http.Transport{
+		DialContext:           (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+	},
+}
 
 // ModelDownloader handles downloading the whisper model from Hugging Face
 type ModelDownloader struct {
@@ -69,7 +83,7 @@ func (d *ModelDownloader) downloadToFile(ctx context.Context, path string) error
 	if err != nil {
 		return fmt.Errorf("failed to create download request: %w", err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to download model: %w", err)
 	}


### PR DESCRIPTION
Make Dabri fully functional inside the Flatpak sandbox: audio capture (arecord -> ffmpeg/PulseAudio with proper WAV finalization), hotkey portal signal handling, and the about-page cache path. 

The headline change adds active-window typing in the sandbox: the RemoteDesktop portal on GNOME/KDE (via the new **go-wlportal** library) and bundled ydotool on wlroots/Hyprland, with clipboard fallback.