### PR TITLE
Hotkeys/stable portal ids

### DIFF
--- a/hotkeys/interfaces/provider.go
+++ b/hotkeys/interfaces/provider.go
@@ -15,8 +15,11 @@ type KeyboardEventProvider interface {
 	Start() error
 	// Stop listening for keyboard events
 	Stop()
-	// Register a hotkey combination and its associated callback function
-	RegisterHotkey(hotkey string, callback func() error) error
+	// Register an action and its callback. id is a stable action identifier
+	// (used as the portal shortcut id, kept constant across rebinds); hotkey is
+	// the desired key combo (matched against physical keys by evdev, and used as
+	// the portal's preferred_trigger).
+	RegisterHotkey(id, hotkey string, callback func() error) error
 	// Check if the provider is supported on the current system
 	IsSupported() bool
 	// Capture a single hotkey combination within a given timeout

--- a/hotkeys/manager/manager_provider_test.go
+++ b/hotkeys/manager/manager_provider_test.go
@@ -178,7 +178,7 @@ func TestHotkeyFactory_InterfaceCompliance(t *testing.T) {
 			t.Errorf("unexpected error starting provider: %v", err)
 		}
 
-		err = provider.RegisterHotkey("test", func() error { return nil })
+		err = provider.RegisterHotkey("test", "test", func() error { return nil })
 		if err != nil {
 			t.Errorf("unexpected error registering hotkey: %v", err)
 		}

--- a/hotkeys/manager/provider_fallback.go
+++ b/hotkeys/manager/provider_fallback.go
@@ -11,10 +11,13 @@ import (
 	"github.com/AshBuk/dabri/v2/hotkeys/providers"
 )
 
+// actionToggleRecording is the stable id for the start/stop recording action.
+const actionToggleRecording = "toggle_recording"
+
 // Register all configured hotkeys on the given provider
 func (h *HotkeyManager) registerAllHotkeysOn(provider interfaces.KeyboardEventProvider) error {
 	// Register the primary start/stop recording hotkey
-	if err := provider.RegisterHotkey(h.config.GetStartRecordingHotkey(), func() error {
+	if err := provider.RegisterHotkey(actionToggleRecording, h.config.GetStartRecordingHotkey(), func() error {
 		// The toggle owns the start/stop decision against the recorder's real
 		// state, so this path holds no recording state of its own.
 		if h.recordingToggle == nil {
@@ -40,7 +43,7 @@ func (h *HotkeyManager) registerAllHotkeysOn(provider interfaces.KeyboardEventPr
 		}
 
 		act := action
-		if err := provider.RegisterHotkey(hk, func() error {
+		if err := provider.RegisterHotkey(actionName, hk, func() error {
 			h.logger.Info("Custom hotkey detected: %s (%s)", actionName, hk)
 			if err := act(); err != nil {
 				h.logger.Error("Error executing hotkey action for %s: %v", actionName, err)

--- a/hotkeys/mocks/mock_provider.go
+++ b/hotkeys/mocks/mock_provider.go
@@ -84,8 +84,8 @@ func (m *MockHotkeyProvider) Stop() {
 	}
 }
 
-// RegisterHotkey simulates registering a hotkey
-func (m *MockHotkeyProvider) RegisterHotkey(hotkey string, callback func() error) error {
+// RegisterHotkey simulates registering an action, keyed by its stable id.
+func (m *MockHotkeyProvider) RegisterHotkey(id, hotkey string, callback func() error) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -103,7 +103,7 @@ func (m *MockHotkeyProvider) RegisterHotkey(hotkey string, callback func() error
 		return errors.New("callback cannot be nil")
 	}
 
-	m.registeredHotkeys[hotkey] = callback
+	m.registeredHotkeys[id] = callback
 	return nil
 }
 

--- a/hotkeys/mocks/mock_provider_extended_test.go
+++ b/hotkeys/mocks/mock_provider_extended_test.go
@@ -16,7 +16,7 @@ func TestMockHotkeyProvider_SetRegisterError(t *testing.T) {
 	provider.SetRegisterError(expectedErr)
 
 	// Try to register a hotkey
-	err := provider.RegisterHotkey("ctrl+r", func() error { return nil })
+	err := provider.RegisterHotkey("ctrl+r", "ctrl+r", func() error { return nil })
 
 	if err != expectedErr {
 		t.Errorf("Expected error %v, got %v", expectedErr, err)
@@ -26,7 +26,7 @@ func TestMockHotkeyProvider_SetRegisterError(t *testing.T) {
 	provider.SetRegisterError(nil)
 
 	// Should work now
-	err = provider.RegisterHotkey("ctrl+r", func() error { return nil })
+	err = provider.RegisterHotkey("ctrl+r", "ctrl+r", func() error { return nil })
 	if err != nil {
 		t.Errorf("Expected no error after clearing, got %v", err)
 	}
@@ -44,7 +44,7 @@ func TestMockHotkeyProvider_GetRegisteredHotkeys(t *testing.T) {
 	// Register some hotkeys
 	testHotkeys := []string{"ctrl+r", "alt+f", "shift+space"}
 	for _, hotkey := range testHotkeys {
-		err := provider.RegisterHotkey(hotkey, func() error { return nil })
+		err := provider.RegisterHotkey(hotkey, hotkey, func() error { return nil })
 		if err != nil {
 			t.Errorf("Failed to register hotkey %s: %v", hotkey, err)
 		}
@@ -78,7 +78,7 @@ func TestMockHotkeyProvider_IsHotkeyRegistered(t *testing.T) {
 	}
 
 	// Register a hotkey
-	err := provider.RegisterHotkey("ctrl+r", func() error { return nil })
+	err := provider.RegisterHotkey("ctrl+r", "ctrl+r", func() error { return nil })
 	if err != nil {
 		t.Errorf("Failed to register hotkey: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestMockHotkeyProvider_SimulateHotkeyPress(t *testing.T) {
 	}
 
 	// Register hotkey
-	err = provider.RegisterHotkey("ctrl+r", callback)
+	err = provider.RegisterHotkey("ctrl+r", "ctrl+r", callback)
 	if err != nil {
 		t.Errorf("Failed to register hotkey: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestMockHotkeyProvider_EnableDisableEventSimulation(t *testing.T) {
 		return nil
 	}
 
-	err := provider.RegisterHotkey("ctrl+r", callback)
+	err := provider.RegisterHotkey("ctrl+r", "ctrl+r", callback)
 	if err != nil {
 		t.Errorf("Failed to register hotkey: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestMockHotkeyProvider_GetCallHistory(t *testing.T) {
 
 	// Perform some operations
 	provider.Start()
-	provider.RegisterHotkey("ctrl+r", func() error { return nil })
+	provider.RegisterHotkey("ctrl+r", "ctrl+r", func() error { return nil })
 	provider.Stop()
 
 	// Check history has entries
@@ -199,7 +199,7 @@ func TestMockHotkeyProvider_Reset(t *testing.T) {
 
 	// Set up some state
 	provider.Start()
-	provider.RegisterHotkey("ctrl+r", func() error { return nil })
+	provider.RegisterHotkey("ctrl+r", "ctrl+r", func() error { return nil })
 	provider.SetStartError(fmt.Errorf("test error"))
 
 	// Verify state exists
@@ -276,7 +276,7 @@ func TestMockHotkeyProvider_GetMethodCallCount(t *testing.T) {
 
 	// Call other methods
 	provider.Stop()
-	provider.RegisterHotkey("ctrl+r", func() error { return nil })
+	provider.RegisterHotkey("ctrl+r", "ctrl+r", func() error { return nil })
 
 	// Check individual counts
 	if provider.GetMethodCallCount("Stop") != 1 {
@@ -317,7 +317,7 @@ func TestMockHotkeyProviderWithErrors_SimulateInvalidHotkey(t *testing.T) {
 	provider.SimulateInvalidHotkey()
 
 	// RegisterHotkey should fail
-	err := provider.RegisterHotkey("ctrl+r", func() error { return nil })
+	err := provider.RegisterHotkey("ctrl+r", "ctrl+r", func() error { return nil })
 	if err == nil {
 		t.Error("RegisterHotkey should fail with invalid hotkey simulation")
 	}
@@ -343,7 +343,7 @@ func TestMockHotkeyProviderWithErrors_SimulateHotkeyConflict(t *testing.T) {
 	provider.SimulateHotkeyConflict()
 
 	// RegisterHotkey should fail
-	err := provider.RegisterHotkey("ctrl+r", func() error { return nil })
+	err := provider.RegisterHotkey("ctrl+r", "ctrl+r", func() error { return nil })
 	if err == nil {
 		t.Error("RegisterHotkey should fail with hotkey conflict simulation")
 	}

--- a/hotkeys/providers/dbus_accelerator_test.go
+++ b/hotkeys/providers/dbus_accelerator_test.go
@@ -79,7 +79,7 @@ func TestDbusProvider_RegisterHotkey(t *testing.T) {
 		return nil
 	}
 
-	err := provider.RegisterHotkey("test+key", callback)
+	err := provider.RegisterHotkey("test+key", "test+key", callback)
 	if err != nil {
 		t.Logf("Expected error in test environment (no D-Bus portal): %v", err)
 	}

--- a/hotkeys/providers/dbus_provider.go
+++ b/hotkeys/providers/dbus_provider.go
@@ -21,7 +21,8 @@ import (
 // Implements KeyboardEventProvider using the GlobalShortcuts portal through the
 // go-wlportal/shortcuts adapter.
 type DbusKeyboardProvider struct {
-	callbacks   map[string]func() error
+	callbacks   map[string]func() error // keyed by stable action id
+	triggers    map[string]string       // action id -> desired key combo
 	session     *shortcuts.Session
 	isListening bool
 	mutex       sync.Mutex
@@ -33,8 +34,24 @@ type DbusKeyboardProvider struct {
 func NewDbusKeyboardProvider(logger logger.Logger) *DbusKeyboardProvider {
 	return &DbusKeyboardProvider{
 		callbacks: make(map[string]func() error),
+		triggers:  make(map[string]string),
 		logger:    logger,
 	}
+}
+
+// actionDescriptions maps stable action ids to human-readable text shown in the
+// compositor's shortcut UI. Unknown ids fall back to the id itself.
+var actionDescriptions = map[string]string{
+	"toggle_recording":  "Start/stop recording",
+	"show_config":       "Open configuration",
+	"reset_to_defaults": "Reset settings to defaults",
+}
+
+func describeAction(id string) string {
+	if d, ok := actionDescriptions[id]; ok {
+		return d
+	}
+	return id
 }
 
 // Check if the D-Bus GlobalShortcuts portal is available
@@ -47,17 +64,18 @@ func (p *DbusKeyboardProvider) IsSupported() bool {
 	return false
 }
 
-// Register a hotkey and its callback. Binding is deferred until Start.
-func (p *DbusKeyboardProvider) RegisterHotkey(hotkey string, callback func() error) error {
+// Register an action and its callback. Binding is deferred until Start.
+func (p *DbusKeyboardProvider) RegisterHotkey(id, hotkey string, callback func() error) error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
-	if _, exists := p.callbacks[hotkey]; exists {
-		return fmt.Errorf("hotkey %s already registered", hotkey)
+	if _, exists := p.callbacks[id]; exists {
+		return fmt.Errorf("action %s already registered", id)
 	}
 
-	p.callbacks[hotkey] = callback
-	p.logger.Info("D-Bus hotkey registered: %s", hotkey)
+	p.callbacks[id] = callback
+	p.triggers[id] = hotkey
+	p.logger.Info("D-Bus action registered: %s (%s)", id, hotkey)
 	return nil
 }
 
@@ -71,15 +89,14 @@ func (p *DbusKeyboardProvider) Start() error {
 		return fmt.Errorf("D-Bus keyboard provider already started")
 	}
 
-	// Build the shortcut list; the hotkey string doubles as the portal ID echoed
-	// back on activation, so callbacks can be looked up by it directly.
-	list := make([]shortcuts.Shortcut, 0, len(p.callbacks))
-	for hotkey := range p.callbacks {
+	// The portal ID is the stable action id (echoed back on activation), so it
+	// stays constant across rebinds; the key is only the preferred_trigger hint.
+	list := make([]shortcuts.Shortcut, 0, len(p.triggers))
+	for id, hotkey := range p.triggers {
 		accel := convertHotkeyToAccelerator(hotkey)
-		p.logger.Info("DBus: Converting hotkey '%s' to accelerator '%s'", hotkey, accel)
 		list = append(list, shortcuts.Shortcut{
-			ID:               hotkey,
-			Description:      fmt.Sprintf("Dabri hotkey: %s", hotkey),
+			ID:               id,
+			Description:      describeAction(id),
 			PreferredTrigger: accel,
 		})
 	}

--- a/hotkeys/providers/dbus_provider_test.go
+++ b/hotkeys/providers/dbus_provider_test.go
@@ -45,7 +45,7 @@ func TestDbusKeyboardProvider_RegisterHotkey(t *testing.T) {
 		return nil
 	}
 	// Test registering a hotkey
-	err := provider.RegisterHotkey("ctrl+shift+a", callback)
+	err := provider.RegisterHotkey("ctrl+shift+a", "ctrl+shift+a", callback)
 	if err != nil {
 		t.Errorf("unexpected error registering hotkey: %v", err)
 	}
@@ -75,16 +75,16 @@ func TestDbusKeyboardProvider_RegisterHotkey_Duplicate(t *testing.T) {
 	provider := NewDbusKeyboardProvider(testutils.NewMockLogger())
 	callback := func() error { return nil }
 	// Register first hotkey
-	err := provider.RegisterHotkey("ctrl+a", callback)
+	err := provider.RegisterHotkey("ctrl+a", "ctrl+a", callback)
 	if err != nil {
 		t.Errorf("unexpected error registering first hotkey: %v", err)
 	}
 	// Try to register the same hotkey again
-	err = provider.RegisterHotkey("ctrl+a", callback)
+	err = provider.RegisterHotkey("ctrl+a", "ctrl+a", callback)
 	if err == nil {
 		t.Error("expected error when registering duplicate hotkey")
 	}
-	if err.Error() != "hotkey ctrl+a already registered" {
+	if err.Error() != "action ctrl+a already registered" {
 		t.Errorf("unexpected error message: %v", err)
 	}
 }

--- a/hotkeys/providers/dummy_provider.go
+++ b/hotkeys/providers/dummy_provider.go
@@ -67,9 +67,9 @@ func (p *DummyKeyboardProvider) Stop() {
 }
 
 // Store the callback but never call it
-func (p *DummyKeyboardProvider) RegisterHotkey(hotkey string, callback func() error) error {
-	p.logger.Info("Registered hotkey: %s (but it will not function with dummy provider)", hotkey)
-	p.callbacks[hotkey] = callback
+func (p *DummyKeyboardProvider) RegisterHotkey(id, hotkey string, callback func() error) error {
+	p.logger.Info("Registered action: %s (%s) (but it will not function with dummy provider)", id, hotkey)
+	p.callbacks[id] = callback
 	return nil
 }
 

--- a/hotkeys/providers/dummy_provider_test.go
+++ b/hotkeys/providers/dummy_provider_test.go
@@ -113,7 +113,7 @@ func TestDummyKeyboardProvider_RegisterHotkey(t *testing.T) {
 	}
 
 	// Register a hotkey
-	err := provider.RegisterHotkey("ctrl+r", callback)
+	err := provider.RegisterHotkey("ctrl+r", "ctrl+r", callback)
 	if err != nil {
 		t.Errorf("RegisterHotkey should not return error, got: %v", err)
 	}
@@ -160,7 +160,7 @@ func TestDummyKeyboardProvider_RegisterMultipleHotkeys(t *testing.T) {
 			return nil
 		}
 
-		err := provider.RegisterHotkey(hotkey, callback)
+		err := provider.RegisterHotkey(hotkey, hotkey, callback)
 		if err != nil {
 			t.Errorf("RegisterHotkey failed for '%s': %v", hotkey, err)
 		}
@@ -210,13 +210,13 @@ func TestDummyKeyboardProvider_OverwriteHotkey(t *testing.T) {
 	}
 
 	// Register first callback
-	err := provider.RegisterHotkey("ctrl+r", firstCallback)
+	err := provider.RegisterHotkey("ctrl+r", "ctrl+r", firstCallback)
 	if err != nil {
 		t.Errorf("RegisterHotkey failed: %v", err)
 	}
 
 	// Register second callback for same hotkey (should overwrite)
-	err = provider.RegisterHotkey("ctrl+r", secondCallback)
+	err = provider.RegisterHotkey("ctrl+r", "ctrl+r", secondCallback)
 	if err != nil {
 		t.Errorf("RegisterHotkey failed: %v", err)
 	}

--- a/hotkeys/providers/evdev_provider.go
+++ b/hotkeys/providers/evdev_provider.go
@@ -252,8 +252,9 @@ func (p *EvdevKeyboardProvider) handleKeyEvent(_ int, event *evdev.InputEvent) {
 	}
 }
 
-// Register a callback for a hotkey
-func (p *EvdevKeyboardProvider) RegisterHotkey(hotkey string, callback func() error) error {
+// Register a callback for a hotkey. evdev owns bindings and matches physical
+// keys, so it keys callbacks by the combo; id is unused here.
+func (p *EvdevKeyboardProvider) RegisterHotkey(id, hotkey string, callback func() error) error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 	p.callbacks[hotkey] = callback

--- a/hotkeys/providers/evdev_provider_test.go
+++ b/hotkeys/providers/evdev_provider_test.go
@@ -52,7 +52,7 @@ func TestEvdevKeyboardProvider_RegisterHotkey(t *testing.T) {
 		return nil
 	}
 	// Test registering a hotkey
-	err := provider.RegisterHotkey("ctrl+shift+a", callback)
+	err := provider.RegisterHotkey("ctrl+shift+a", "ctrl+shift+a", callback)
 	if err != nil {
 		t.Errorf("unexpected error registering hotkey: %v", err)
 	}

--- a/internal/ui/tray/settings_menu.go
+++ b/internal/ui/tray/settings_menu.go
@@ -432,6 +432,17 @@ func (tm *TrayManager) updateHotkeysMenuUI() {
 	for _, cfg := range hotkeyConfigs {
 		tm.createHotkeyMenuItem(cfg, supportsCaptureOnce)
 	}
+
+	// Without capture-once (portal path) bindings are owned by the compositor and
+	// can only be changed in the system settings, so note that instead of rebind.
+	if !supportsCaptureOnce && tm.hotkeyItems["rebind_note"] == nil {
+		note := tm.hotkeysMenu.AddSubMenuItem(
+			"Set shortcuts in system settings",
+			"On Wayland, global shortcuts are managed by the desktop's Keyboard Shortcuts",
+		)
+		note.Disable()
+		tm.hotkeyItems["rebind_note"] = note
+	}
 }
 
 // updateRecorderRadioUI updates titles to emulate radio selection


### PR DESCRIPTION
The GlobalShortcuts portal persists bindings per shortcut ID.
Hide the in-app hotkey rebinding controls when the GlobalShortcuts portal is the active provider, since the compositor owns those bindings and they can't be changed from within the app.


> Known issue: on GNOME 50 the shortcut bind dialog is rendered blank (no text)
> due to an upstream regression in `xdg-desktop-portal-gnome`
> ([#211](https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/issues/211)).
> The dialog is still functional — confirming it binds the shortcuts as usual.