### PR TITLE
whisper: log model download progress

### DIFF
--- a/internal/services/factory_components.go
+++ b/internal/services/factory_components.go
@@ -45,7 +45,7 @@ func NewFactoryComponents(config ServiceFactoryConfig) *FactoryComponents {
 func (cf *FactoryComponents) InitializeComponents() (*Components, error) {
 	components := &Components{}
 	// Initialize model manager
-	components.ModelManager = whisper.NewModelManager(cf.config.Config)
+	components.ModelManager = whisper.NewModelManager(cf.config.Config, cf.config.Logger)
 	if err := components.ModelManager.Initialize(cf.config.Ctx); err != nil {
 		cf.config.Logger.Warning("Failed to initialize model manager: %v", err)
 	}

--- a/whisper/manager/model_manager.go
+++ b/whisper/manager/model_manager.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/AshBuk/dabri/v2/config"
 	"github.com/AshBuk/dabri/v2/internal/constants"
+	"github.com/AshBuk/dabri/v2/internal/logger"
 	"github.com/AshBuk/dabri/v2/internal/utils"
 	"github.com/AshBuk/dabri/v2/whisper/providers"
 )
@@ -17,11 +18,17 @@ import (
 // Manages Whisper model lifecycle: resolution, download, and validation
 type ModelManager struct {
 	config *config.Config
+	logger logger.Logger
 }
 
-// Create a new manager responsible for the Whisper model
-func NewModelManager(config *config.Config) *ModelManager {
-	return &ModelManager{config: config}
+// Create a new manager responsible for the Whisper model.
+// An optional logger enables download-progress reporting.
+func NewModelManager(config *config.Config, loggers ...logger.Logger) *ModelManager {
+	m := &ModelManager{config: config}
+	if len(loggers) > 0 {
+		m.logger = loggers[0]
+	}
+	return m
 }
 
 // Initialize validates the configured model is present, downloading if needed
@@ -76,6 +83,18 @@ func (m *ModelManager) resolveModel(ctx context.Context, modelID string) (string
 	// Download to user data directory
 	downloadPath := resolver.GetUserDataModelPath()
 	dl := providers.NewModelDownloaderForURL(def.URL, def.MinSize)
+	if m.logger != nil {
+		m.logger.Info("Downloading model %s (%s)...", modelID, def.FileName)
+		dl.WithProgress(func(downloaded, total int64) {
+			const mb = 1024 * 1024
+			if total > 0 {
+				m.logger.Info("Downloading model %s: %d%% (%.1f/%.1f MB)",
+					modelID, downloaded*100/total, float64(downloaded)/mb, float64(total)/mb)
+			} else {
+				m.logger.Info("Downloading model %s: %.1f MB", modelID, float64(downloaded)/mb)
+			}
+		})
+	}
 	if err := dl.Download(ctx, downloadPath); err != nil {
 		return "", fmt.Errorf("failed to download model %s: %w", modelID, err)
 	}

--- a/whisper/providers/model_downloader.go
+++ b/whisper/providers/model_downloader.go
@@ -26,15 +26,26 @@ var httpClient = &http.Client{
 	},
 }
 
+// ProgressFunc reports download progress: bytes downloaded so far and the total
+// size in bytes (total is -1 when the server omits Content-Length).
+type ProgressFunc func(downloaded, total int64)
+
 // ModelDownloader handles downloading the whisper model from Hugging Face
 type ModelDownloader struct {
-	url     string
-	minSize int64
+	url      string
+	minSize  int64
+	progress ProgressFunc
 }
 
 // NewModelDownloaderForURL creates a downloader for the given URL and minimum size
 func NewModelDownloaderForURL(url string, minSize int64) *ModelDownloader {
 	return &ModelDownloader{url: url, minSize: minSize}
+}
+
+// WithProgress registers a callback invoked periodically during download.
+func (d *ModelDownloader) WithProgress(fn ProgressFunc) *ModelDownloader {
+	d.progress = fn
+	return d
 }
 
 // Download downloads the model to the specified path.
@@ -101,12 +112,41 @@ func (d *ModelDownloader) downloadToFile(ctx context.Context, path string) error
 	}
 	defer func() { _ = out.Close() }()
 
-	// Copy response body to file
-	_, err = io.Copy(out, resp.Body)
-	if err != nil {
+	// Copy response body to file, reporting progress if a callback is set
+	var dst io.Writer = out
+	if d.progress != nil {
+		pw := &progressWriter{total: resp.ContentLength, fn: d.progress}
+		dst = io.MultiWriter(out, pw)
+		defer pw.flush() // emit a final report at completion
+	}
+	if _, err = io.Copy(dst, resp.Body); err != nil {
 		return fmt.Errorf("failed to write model file: %w", err)
 	}
 	return nil
+}
+
+// progressWriter counts bytes written and forwards throttled progress reports.
+type progressWriter struct {
+	total      int64
+	downloaded int64
+	fn         ProgressFunc
+	lastReport time.Time
+}
+
+func (p *progressWriter) Write(b []byte) (int, error) {
+	n := len(b)
+	p.downloaded += int64(n)
+	// Throttle to at most one report per second to avoid log spam
+	if time.Since(p.lastReport) >= time.Second {
+		p.lastReport = time.Now()
+		p.fn(p.downloaded, p.total)
+	}
+	return n, nil
+}
+
+// flush emits a final report with the total bytes downloaded.
+func (p *progressWriter) flush() {
+	p.fn(p.downloaded, p.total)
 }
 
 // GetModelURL returns the download URL

--- a/whisper/providers/model_downloader_test.go
+++ b/whisper/providers/model_downloader_test.go
@@ -42,6 +42,38 @@ func TestModelDownloader_Download_Success(t *testing.T) {
 	}
 }
 
+func TestModelDownloader_Download_ReportsProgress(t *testing.T) {
+	modelData := strings.Repeat("x", testMinSize+1000)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(modelData))
+	}))
+	defer server.Close()
+
+	var lastDownloaded, lastTotal int64
+	calls := 0
+	downloader := NewModelDownloaderForURL(server.URL, testMinSize).
+		WithProgress(func(downloaded, total int64) {
+			calls++
+			lastDownloaded, lastTotal = downloaded, total
+		})
+
+	destPath := filepath.Join(t.TempDir(), "models", "test_model.bin")
+	if err := downloader.Download(context.Background(), destPath); err != nil {
+		t.Fatalf("Download failed: %v", err)
+	}
+	// The final flush always fires, so we expect at least one report ending at 100%.
+	if calls == 0 {
+		t.Fatal("progress callback was never invoked")
+	}
+	if lastDownloaded != int64(len(modelData)) {
+		t.Errorf("final progress: expected %d bytes, got %d", len(modelData), lastDownloaded)
+	}
+	if lastTotal != int64(len(modelData)) {
+		t.Errorf("expected total %d from Content-Length, got %d", len(modelData), lastTotal)
+	}
+}
+
 func TestModelDownloader_Download_HTTPError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)

--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -13,6 +13,7 @@ package whisper
 
 import (
 	"github.com/AshBuk/dabri/v2/config"
+	"github.com/AshBuk/dabri/v2/internal/logger"
 	"github.com/AshBuk/dabri/v2/whisper/interfaces"
 	"github.com/AshBuk/dabri/v2/whisper/manager"
 )
@@ -22,7 +23,8 @@ type (
 	ModelManager = interfaces.ModelManager
 )
 
-// Create a new manager for the bundled Whisper model
-func NewModelManager(config *config.Config) ModelManager {
-	return manager.NewModelManager(config)
+// Create a new manager for the bundled Whisper model.
+// An optional logger enables download-progress reporting.
+func NewModelManager(config *config.Config, loggers ...logger.Logger) ModelManager {
+	return manager.NewModelManager(config, loggers...)
 }


### PR DESCRIPTION
The first-run model download blocked service init with no output, which looked like a hang. Add an optional progress callback to the downloader and emit throttled progress (once/sec + final) to the log via the model manager.