### PR TITLE
Fix Unicode active-window output on KDE Wayland

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage.out
 
 # Project executables
 /dabri
+/dabri/
 /dabri-cli
 /daemon
 /cli

--- a/config/loaders/default_config.yaml
+++ b/config/loaders/default_config.yaml
@@ -32,6 +32,7 @@ output:
   default_mode: "active_window"  # Options: "clipboard", "active_window"
   clipboard_tool: "auto"         # Options: "auto", "wl-copy", "xsel"
   type_tool: "auto"              # Options: "auto", "ydotool", "xdotool", "wl-clipboard", "dbus"
+  paste_shortcut: "ctrl+v"       # Clipboard paste fallback: "ctrl+v", "ctrl+shift+v", "shift+insert"
 
 # Desktop notification settings
 notifications:

--- a/config/loaders/default_config.yaml
+++ b/config/loaders/default_config.yaml
@@ -32,7 +32,6 @@ output:
   default_mode: "active_window"  # Options: "clipboard", "active_window"
   clipboard_tool: "auto"         # Options: "auto", "wl-copy", "xsel"
   type_tool: "auto"              # Options: "auto", "ydotool", "xdotool", "wl-clipboard", "dbus"
-  paste_shortcut: "ctrl+v"       # Clipboard paste fallback: "ctrl+v", "ctrl+shift+v", "shift+insert"
 
 # Desktop notification settings
 notifications:

--- a/config/loaders/default_config.yaml
+++ b/config/loaders/default_config.yaml
@@ -32,6 +32,7 @@ output:
   default_mode: "active_window"  # Options: "clipboard", "active_window"
   clipboard_tool: "auto"         # Options: "auto", "wl-copy", "xsel"
   type_tool: "auto"              # Options: "auto", "ydotool", "xdotool", "wl-clipboard", "dbus"
+  paste_shortcut: "shift+insert" # Clipboard paste fallback: "shift+insert", "ctrl+v"
 
 # Desktop notification settings
 notifications:

--- a/config/models/config.go
+++ b/config/models/config.go
@@ -44,6 +44,7 @@ type Config struct {
 		DefaultMode   string `yaml:"default_mode"`   // Default output mode: "clipboard" or "active_window"
 		ClipboardTool string `yaml:"clipboard_tool"` // Tool for clipboard operations (e.g., "wl-copy", "xsel"). "auto" for detection
 		TypeTool      string `yaml:"type_tool"`      // Tool for typing text (e.g., "xdotool", "wtype"). "auto" for detection
+		PasteShortcut string `yaml:"paste_shortcut"` // Shortcut for clipboard paste fallback: "shift+insert" or "ctrl+v"
 	} `yaml:"output"`
 
 	Notifications struct {

--- a/config/models/config.go
+++ b/config/models/config.go
@@ -44,6 +44,7 @@ type Config struct {
 		DefaultMode   string `yaml:"default_mode"`   // Default output mode: "clipboard" or "active_window"
 		ClipboardTool string `yaml:"clipboard_tool"` // Tool for clipboard operations (e.g., "wl-copy", "xsel"). "auto" for detection
 		TypeTool      string `yaml:"type_tool"`      // Tool for typing text (e.g., "xdotool", "wtype"). "auto" for detection
+		PasteShortcut string `yaml:"paste_shortcut"` // Shortcut for clipboard paste fallback: "ctrl+v", "ctrl+shift+v", or "shift+insert"
 	} `yaml:"output"`
 
 	Notifications struct {

--- a/config/models/config.go
+++ b/config/models/config.go
@@ -44,7 +44,6 @@ type Config struct {
 		DefaultMode   string `yaml:"default_mode"`   // Default output mode: "clipboard" or "active_window"
 		ClipboardTool string `yaml:"clipboard_tool"` // Tool for clipboard operations (e.g., "wl-copy", "xsel"). "auto" for detection
 		TypeTool      string `yaml:"type_tool"`      // Tool for typing text (e.g., "xdotool", "wtype"). "auto" for detection
-		PasteShortcut string `yaml:"paste_shortcut"` // Shortcut for clipboard paste fallback: "ctrl+v", "ctrl+shift+v", or "shift+insert"
 	} `yaml:"output"`
 
 	Notifications struct {

--- a/config/validators/standard_validator.go
+++ b/config/validators/standard_validator.go
@@ -78,20 +78,6 @@ func validateWebServerConfig(config *models.Config, errors *[]string) {
 	}
 }
 
-func validateOutputConfig(config *models.Config, errors *[]string) {
-	shortcut := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(config.Output.PasteShortcut), " ", ""))
-	if shortcut == "" {
-		shortcut = "ctrl+v"
-	}
-	switch shortcut {
-	case "ctrl+v", "ctrl+shift+v", "shift+insert":
-		config.Output.PasteShortcut = shortcut
-	default:
-		*errors = append(*errors, fmt.Sprintf("invalid paste shortcut: %s, correcting to 'ctrl+v'", config.Output.PasteShortcut))
-		config.Output.PasteShortcut = "ctrl+v"
-	}
-}
-
 // validateSecurityConfig validates security configuration settings
 func validateSecurityConfig(config *models.Config, errors *[]string) {
 	// Ensure there's always a baseline of allowed commands for security
@@ -110,7 +96,6 @@ func ValidateConfig(config *models.Config) error {
 	validateGeneralConfig(config, &errors)
 	validateAudioConfig(config, &errors)
 	validateWebServerConfig(config, &errors)
-	validateOutputConfig(config, &errors)
 	validateSecurityConfig(config, &errors)
 
 	if len(errors) > 0 {

--- a/config/validators/standard_validator.go
+++ b/config/validators/standard_validator.go
@@ -78,11 +78,25 @@ func validateWebServerConfig(config *models.Config, errors *[]string) {
 	}
 }
 
+func validateOutputConfig(config *models.Config, errors *[]string) {
+	shortcut := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(config.Output.PasteShortcut), " ", ""))
+	if shortcut == "" {
+		shortcut = "ctrl+v"
+	}
+	switch shortcut {
+	case "ctrl+v", "ctrl+shift+v", "shift+insert":
+		config.Output.PasteShortcut = shortcut
+	default:
+		*errors = append(*errors, fmt.Sprintf("invalid paste shortcut: %s, correcting to 'ctrl+v'", config.Output.PasteShortcut))
+		config.Output.PasteShortcut = "ctrl+v"
+	}
+}
+
 // validateSecurityConfig validates security configuration settings
 func validateSecurityConfig(config *models.Config, errors *[]string) {
 	// Ensure there's always a baseline of allowed commands for security
 	if len(config.Security.AllowedCommands) == 0 {
-		config.Security.AllowedCommands = []string{"arecord", "ffmpeg", "whisper", "xdotool", "wl-copy", "xsel"}
+		config.Security.AllowedCommands = []string{"arecord", "ffmpeg", "whisper", "xdotool", "wtype", "ydotool", "wl-copy", "wl-paste", "xsel"}
 		*errors = append(*errors, "allowed_commands was empty, populated with defaults")
 	}
 }
@@ -96,6 +110,7 @@ func ValidateConfig(config *models.Config) error {
 	validateGeneralConfig(config, &errors)
 	validateAudioConfig(config, &errors)
 	validateWebServerConfig(config, &errors)
+	validateOutputConfig(config, &errors)
 	validateSecurityConfig(config, &errors)
 
 	if len(errors) > 0 {

--- a/config/validators/standard_validator.go
+++ b/config/validators/standard_validator.go
@@ -78,6 +78,20 @@ func validateWebServerConfig(config *models.Config, errors *[]string) {
 	}
 }
 
+func validateOutputConfig(config *models.Config, errors *[]string) {
+	shortcut := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(config.Output.PasteShortcut), " ", ""))
+	if shortcut == "" {
+		shortcut = "shift+insert"
+	}
+	switch shortcut {
+	case "shift+insert", "ctrl+v":
+		config.Output.PasteShortcut = shortcut
+	default:
+		*errors = append(*errors, fmt.Sprintf("invalid paste shortcut: %s, correcting to 'shift+insert'", config.Output.PasteShortcut))
+		config.Output.PasteShortcut = "shift+insert"
+	}
+}
+
 // validateSecurityConfig validates security configuration settings
 func validateSecurityConfig(config *models.Config, errors *[]string) {
 	// Ensure there's always a baseline of allowed commands for security
@@ -96,6 +110,7 @@ func ValidateConfig(config *models.Config) error {
 	validateGeneralConfig(config, &errors)
 	validateAudioConfig(config, &errors)
 	validateWebServerConfig(config, &errors)
+	validateOutputConfig(config, &errors)
 	validateSecurityConfig(config, &errors)
 
 	if len(errors) > 0 {

--- a/config/validators/standard_validator_test.go
+++ b/config/validators/standard_validator_test.go
@@ -26,6 +26,7 @@ func setDefaultConfigForTest(config *models.Config) {
 	config.Output.DefaultMode = models.OutputModeActiveWindow
 	config.Output.ClipboardTool = "auto"
 	config.Output.TypeTool = "auto"
+	config.Output.PasteShortcut = "shift+insert"
 
 	config.Security.AllowedCommands = []string{"arecord", "ffmpeg", "whisper", "xdotool", "wtype", "ydotool", "wl-copy", "wl-paste", "xsel", "notify-send", "xdg-open"}
 	config.Security.CheckIntegrity = false
@@ -105,6 +106,32 @@ func TestValidateConfig(t *testing.T) {
 				"recordingMethod": "arecord",
 			},
 		},
+		{
+			name: "paste shortcut",
+			setupConfig: func() *models.Config {
+				config := &models.Config{}
+				setDefaultConfigForTest(config)
+				config.Output.PasteShortcut = "Ctrl + V"
+				return config
+			},
+			expectError: false,
+			expectedValues: map[string]interface{}{
+				"pasteShortcut": "ctrl+v",
+			},
+		},
+		{
+			name: "invalid paste shortcut",
+			setupConfig: func() *models.Config {
+				config := &models.Config{}
+				setDefaultConfigForTest(config)
+				config.Output.PasteShortcut = "ctrl+shift+v"
+				return config
+			},
+			expectError: true,
+			expectedValues: map[string]interface{}{
+				"pasteShortcut": "shift+insert",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -132,6 +159,11 @@ func TestValidateConfig(t *testing.T) {
 			if recordingMethod, ok := tt.expectedValues["recordingMethod"]; ok {
 				if config.Audio.RecordingMethod != recordingMethod {
 					t.Errorf("expected RecordingMethod %v, got %v", recordingMethod, config.Audio.RecordingMethod)
+				}
+			}
+			if pasteShortcut, ok := tt.expectedValues["pasteShortcut"]; ok {
+				if config.Output.PasteShortcut != pasteShortcut {
+					t.Errorf("expected PasteShortcut %v, got %v", pasteShortcut, config.Output.PasteShortcut)
 				}
 			}
 		})

--- a/config/validators/standard_validator_test.go
+++ b/config/validators/standard_validator_test.go
@@ -26,7 +26,6 @@ func setDefaultConfigForTest(config *models.Config) {
 	config.Output.DefaultMode = models.OutputModeActiveWindow
 	config.Output.ClipboardTool = "auto"
 	config.Output.TypeTool = "auto"
-	config.Output.PasteShortcut = "ctrl+v"
 
 	config.Security.AllowedCommands = []string{"arecord", "ffmpeg", "whisper", "xdotool", "wtype", "ydotool", "wl-copy", "wl-paste", "xsel", "notify-send", "xdg-open"}
 	config.Security.CheckIntegrity = false
@@ -106,32 +105,6 @@ func TestValidateConfig(t *testing.T) {
 				"recordingMethod": "arecord",
 			},
 		},
-		{
-			name: "terminal paste shortcut",
-			setupConfig: func() *models.Config {
-				config := &models.Config{}
-				setDefaultConfigForTest(config)
-				config.Output.PasteShortcut = "Ctrl + Shift + V"
-				return config
-			},
-			expectError: false,
-			expectedValues: map[string]interface{}{
-				"pasteShortcut": "ctrl+shift+v",
-			},
-		},
-		{
-			name: "invalid paste shortcut",
-			setupConfig: func() *models.Config {
-				config := &models.Config{}
-				setDefaultConfigForTest(config)
-				config.Output.PasteShortcut = "super+v"
-				return config
-			},
-			expectError: true,
-			expectedValues: map[string]interface{}{
-				"pasteShortcut": "ctrl+v",
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -159,11 +132,6 @@ func TestValidateConfig(t *testing.T) {
 			if recordingMethod, ok := tt.expectedValues["recordingMethod"]; ok {
 				if config.Audio.RecordingMethod != recordingMethod {
 					t.Errorf("expected RecordingMethod %v, got %v", recordingMethod, config.Audio.RecordingMethod)
-				}
-			}
-			if pasteShortcut, ok := tt.expectedValues["pasteShortcut"]; ok {
-				if config.Output.PasteShortcut != pasteShortcut {
-					t.Errorf("expected PasteShortcut %v, got %v", pasteShortcut, config.Output.PasteShortcut)
 				}
 			}
 		})

--- a/config/validators/standard_validator_test.go
+++ b/config/validators/standard_validator_test.go
@@ -26,6 +26,7 @@ func setDefaultConfigForTest(config *models.Config) {
 	config.Output.DefaultMode = models.OutputModeActiveWindow
 	config.Output.ClipboardTool = "auto"
 	config.Output.TypeTool = "auto"
+	config.Output.PasteShortcut = "ctrl+v"
 
 	config.Security.AllowedCommands = []string{"arecord", "ffmpeg", "whisper", "xdotool", "wtype", "ydotool", "wl-copy", "wl-paste", "xsel", "notify-send", "xdg-open"}
 	config.Security.CheckIntegrity = false
@@ -105,6 +106,32 @@ func TestValidateConfig(t *testing.T) {
 				"recordingMethod": "arecord",
 			},
 		},
+		{
+			name: "terminal paste shortcut",
+			setupConfig: func() *models.Config {
+				config := &models.Config{}
+				setDefaultConfigForTest(config)
+				config.Output.PasteShortcut = "Ctrl + Shift + V"
+				return config
+			},
+			expectError: false,
+			expectedValues: map[string]interface{}{
+				"pasteShortcut": "ctrl+shift+v",
+			},
+		},
+		{
+			name: "invalid paste shortcut",
+			setupConfig: func() *models.Config {
+				config := &models.Config{}
+				setDefaultConfigForTest(config)
+				config.Output.PasteShortcut = "super+v"
+				return config
+			},
+			expectError: true,
+			expectedValues: map[string]interface{}{
+				"pasteShortcut": "ctrl+v",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -132,6 +159,11 @@ func TestValidateConfig(t *testing.T) {
 			if recordingMethod, ok := tt.expectedValues["recordingMethod"]; ok {
 				if config.Audio.RecordingMethod != recordingMethod {
 					t.Errorf("expected RecordingMethod %v, got %v", recordingMethod, config.Audio.RecordingMethod)
+				}
+			}
+			if pasteShortcut, ok := tt.expectedValues["pasteShortcut"]; ok {
+				if config.Output.PasteShortcut != pasteShortcut {
+					t.Errorf("expected PasteShortcut %v, got %v", pasteShortcut, config.Output.PasteShortcut)
 				}
 			}
 		})

--- a/output/factory/factory.go
+++ b/output/factory/factory.go
@@ -164,17 +164,35 @@ func (f *Factory) createClipboardOutputter(env EnvironmentType) (interfaces.Outp
 // extra device permissions. Otherwise it falls back to a CLI tool.
 func (f *Factory) createTypeOutputter(env EnvironmentType) (interfaces.Outputter, error) {
 	if env == EnvironmentWayland && f.config.Output.TypeTool == "auto" && outputters.PortalRemoteDesktopAvailable() {
-		// Text the portal cannot type (non-ASCII) is handled one level up by
-		// IOService, which switches the whole output mode to clipboard.
+		// Text the portal cannot type (non-ASCII) is handled by the paste fallback.
 		if out, err := outputters.NewPortalOutputter(); err == nil {
-			return out, nil
+			return f.withWaylandPasteFallback(env, out)
 		}
 	}
 	tool := f.selectTypeTool(env)
 	if tool != "" && !config.IsCommandAllowed(f.config, tool) {
 		return nil, fmt.Errorf("type tool not allowed: %s", tool)
 	}
-	return outputters.NewTypeOutputter(tool, f.config)
+	out, err := outputters.NewTypeOutputter(tool, f.config)
+	if err != nil {
+		return nil, err
+	}
+	return f.withWaylandPasteFallback(env, out)
+}
+
+func (f *Factory) withWaylandPasteFallback(env EnvironmentType, out interfaces.Outputter) (interfaces.Outputter, error) {
+	if env != EnvironmentWayland || !f.isToolAvailable("ydotool") {
+		return out, nil
+	}
+	clipboardTool := f.selectClipboardTool(env)
+	if clipboardTool != "wl-copy" || !config.IsCommandAllowed(f.config, "ydotool") {
+		return out, nil
+	}
+	clipboard, err := f.createClipboardOutputter(env)
+	if err != nil {
+		return out, nil
+	}
+	return outputters.NewAutoPasteOutputter(out, clipboard, "ydotool", f.config), nil
 }
 
 // Create an outputter directly from a configuration

--- a/output/outputters/auto_paste_outputter.go
+++ b/output/outputters/auto_paste_outputter.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
+package outputters
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/AshBuk/dabri/v2/config"
+	"github.com/AshBuk/dabri/v2/output/interfaces"
+)
+
+const (
+	pasteToolYdotool         = "ydotool"
+	pasteShortcutCtrlV       = "ctrl+v"
+	pasteShortcutCtrlShiftV  = "ctrl+shift+v"
+	pasteShortcutShiftInsert = "shift+insert"
+	keyLeftCtrl              = "29"
+	keyLeftShift             = "42"
+	keyV                     = "47"
+	keyInsert                = "110"
+)
+
+// AutoPasteOutputter types ASCII normally and pastes non-ASCII text via clipboard.
+type AutoPasteOutputter struct {
+	typing     interfaces.Outputter
+	clipboard  interfaces.Outputter
+	pasteTool  string
+	config     *config.Config
+	pasteDelay time.Duration
+}
+
+// NewAutoPasteOutputter creates an outputter that uses Ctrl+V for Unicode text.
+func NewAutoPasteOutputter(typing, clipboard interfaces.Outputter, pasteTool string, cfg *config.Config) interfaces.Outputter {
+	return &AutoPasteOutputter{
+		typing:     typing,
+		clipboard:  clipboard,
+		pasteTool:  pasteTool,
+		config:     cfg,
+		pasteDelay: 80 * time.Millisecond,
+	}
+}
+
+// CopyToClipboard delegates clipboard writes to the configured clipboard backend.
+func (o *AutoPasteOutputter) CopyToClipboard(text string) error {
+	return o.clipboard.CopyToClipboard(text)
+}
+
+// TypeToActiveWindow sends ASCII through the typing backend and Unicode through paste.
+func (o *AutoPasteOutputter) TypeToActiveWindow(text string) error {
+	if !isNonASCII(text) {
+		return o.typing.TypeToActiveWindow(text)
+	}
+	if err := o.clipboard.CopyToClipboard(text); err != nil {
+		return err
+	}
+	time.Sleep(o.pasteDelay)
+	return o.pressPaste()
+}
+
+// GetToolNames reports the composed clipboard and typing tools.
+func (o *AutoPasteOutputter) GetToolNames() (clipboardTool, typeTool string) {
+	clipboardTool, _ = o.clipboard.GetToolNames()
+	_, typeTool = o.typing.GetToolNames()
+	if typeTool == "" {
+		typeTool = o.pasteTool
+	}
+	return clipboardTool, typeTool + "+paste"
+}
+
+func (o *AutoPasteOutputter) pressPaste() error {
+	if !config.IsCommandAllowed(o.config, o.pasteTool) {
+		return fmt.Errorf("paste tool not allowed: %s", o.pasteTool)
+	}
+	if o.pasteTool != pasteToolYdotool {
+		return fmt.Errorf("unsupported paste tool: %s", o.pasteTool)
+	}
+	if _, err := exec.LookPath(o.pasteTool); err != nil {
+		return fmt.Errorf("paste tool not found: %s", o.pasteTool)
+	}
+
+	args, err := pasteKeyArgs(o.config.Output.PasteShortcut)
+	if err != nil {
+		return err
+	}
+	// #nosec G204 -- Tool is allowlisted; arguments are fixed key codes.
+	cmd := exec.Command(o.pasteTool, args...)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to paste with %s: %w, output: %s", o.pasteTool, err, string(output))
+	}
+	return nil
+}
+
+func pasteKeyArgs(shortcut string) ([]string, error) {
+	switch normalizePasteShortcut(shortcut) {
+	case pasteShortcutCtrlV:
+		return []string{"key", keyLeftCtrl + ":1", keyV + ":1", keyV + ":0", keyLeftCtrl + ":0"}, nil
+	case pasteShortcutCtrlShiftV:
+		return []string{"key", keyLeftCtrl + ":1", keyLeftShift + ":1", keyV + ":1", keyV + ":0", keyLeftShift + ":0", keyLeftCtrl + ":0"}, nil
+	case pasteShortcutShiftInsert:
+		return []string{"key", keyLeftShift + ":1", keyInsert + ":1", keyInsert + ":0", keyLeftShift + ":0"}, nil
+	default:
+		return nil, fmt.Errorf("unsupported paste shortcut: %s", shortcut)
+	}
+}
+
+func normalizePasteShortcut(shortcut string) string {
+	shortcut = strings.ToLower(strings.TrimSpace(shortcut))
+	if shortcut == "" {
+		return pasteShortcutCtrlV
+	}
+	return strings.ReplaceAll(shortcut, " ", "")
+}

--- a/output/outputters/auto_paste_outputter.go
+++ b/output/outputters/auto_paste_outputter.go
@@ -6,6 +6,7 @@ package outputters
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/AshBuk/dabri/v2/config"
@@ -13,9 +14,13 @@ import (
 )
 
 const (
-	pasteToolYdotool = "ydotool"
-	keyLeftCtrl      = "29"
-	keyV             = "47"
+	pasteToolYdotool         = "ydotool"
+	pasteShortcutCtrlV       = "ctrl+v"
+	pasteShortcutShiftInsert = "shift+insert"
+	keyLeftCtrl              = "29"
+	keyLeftShift             = "42"
+	keyV                     = "47"
+	keyInsert                = "110"
 )
 
 // AutoPasteOutputter types ASCII normally and pastes non-ASCII text via clipboard.
@@ -27,7 +32,7 @@ type AutoPasteOutputter struct {
 	pasteDelay time.Duration
 }
 
-// NewAutoPasteOutputter creates an outputter that uses Ctrl+V for Unicode text.
+// NewAutoPasteOutputter creates an outputter that pastes Unicode text.
 func NewAutoPasteOutputter(typing, clipboard interfaces.Outputter, pasteTool string, cfg *config.Config) interfaces.Outputter {
 	return &AutoPasteOutputter{
 		typing:     typing,
@@ -76,11 +81,33 @@ func (o *AutoPasteOutputter) pressPaste() error {
 		return fmt.Errorf("paste tool not found: %s", o.pasteTool)
 	}
 
-	args := []string{"key", keyLeftCtrl + ":1", keyV + ":1", keyV + ":0", keyLeftCtrl + ":0"}
+	args, err := pasteKeyArgs(o.config.Output.PasteShortcut)
+	if err != nil {
+		return err
+	}
 	// #nosec G204 -- Tool is allowlisted; arguments are fixed key codes.
 	cmd := exec.Command(o.pasteTool, args...)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to paste with %s: %w, output: %s", o.pasteTool, err, string(output))
 	}
 	return nil
+}
+
+func pasteKeyArgs(shortcut string) ([]string, error) {
+	switch normalizePasteShortcut(shortcut) {
+	case pasteShortcutShiftInsert:
+		return []string{"key", keyLeftShift + ":1", keyInsert + ":1", keyInsert + ":0", keyLeftShift + ":0"}, nil
+	case pasteShortcutCtrlV:
+		return []string{"key", keyLeftCtrl + ":1", keyV + ":1", keyV + ":0", keyLeftCtrl + ":0"}, nil
+	default:
+		return nil, fmt.Errorf("unsupported paste shortcut: %s", shortcut)
+	}
+}
+
+func normalizePasteShortcut(shortcut string) string {
+	shortcut = strings.ToLower(strings.TrimSpace(shortcut))
+	if shortcut == "" {
+		return pasteShortcutShiftInsert
+	}
+	return strings.ReplaceAll(shortcut, " ", "")
 }

--- a/output/outputters/auto_paste_outputter.go
+++ b/output/outputters/auto_paste_outputter.go
@@ -6,7 +6,6 @@ package outputters
 import (
 	"fmt"
 	"os/exec"
-	"strings"
 	"time"
 
 	"github.com/AshBuk/dabri/v2/config"
@@ -14,14 +13,9 @@ import (
 )
 
 const (
-	pasteToolYdotool         = "ydotool"
-	pasteShortcutCtrlV       = "ctrl+v"
-	pasteShortcutCtrlShiftV  = "ctrl+shift+v"
-	pasteShortcutShiftInsert = "shift+insert"
-	keyLeftCtrl              = "29"
-	keyLeftShift             = "42"
-	keyV                     = "47"
-	keyInsert                = "110"
+	pasteToolYdotool = "ydotool"
+	keyLeftCtrl      = "29"
+	keyV             = "47"
 )
 
 // AutoPasteOutputter types ASCII normally and pastes non-ASCII text via clipboard.
@@ -82,35 +76,11 @@ func (o *AutoPasteOutputter) pressPaste() error {
 		return fmt.Errorf("paste tool not found: %s", o.pasteTool)
 	}
 
-	args, err := pasteKeyArgs(o.config.Output.PasteShortcut)
-	if err != nil {
-		return err
-	}
+	args := []string{"key", keyLeftCtrl + ":1", keyV + ":1", keyV + ":0", keyLeftCtrl + ":0"}
 	// #nosec G204 -- Tool is allowlisted; arguments are fixed key codes.
 	cmd := exec.Command(o.pasteTool, args...)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to paste with %s: %w, output: %s", o.pasteTool, err, string(output))
 	}
 	return nil
-}
-
-func pasteKeyArgs(shortcut string) ([]string, error) {
-	switch normalizePasteShortcut(shortcut) {
-	case pasteShortcutCtrlV:
-		return []string{"key", keyLeftCtrl + ":1", keyV + ":1", keyV + ":0", keyLeftCtrl + ":0"}, nil
-	case pasteShortcutCtrlShiftV:
-		return []string{"key", keyLeftCtrl + ":1", keyLeftShift + ":1", keyV + ":1", keyV + ":0", keyLeftShift + ":0", keyLeftCtrl + ":0"}, nil
-	case pasteShortcutShiftInsert:
-		return []string{"key", keyLeftShift + ":1", keyInsert + ":1", keyInsert + ":0", keyLeftShift + ":0"}, nil
-	default:
-		return nil, fmt.Errorf("unsupported paste shortcut: %s", shortcut)
-	}
-}
-
-func normalizePasteShortcut(shortcut string) string {
-	shortcut = strings.ToLower(strings.TrimSpace(shortcut))
-	if shortcut == "" {
-		return pasteShortcutCtrlV
-	}
-	return strings.ReplaceAll(shortcut, " ", "")
 }

--- a/output/outputters/auto_paste_outputter_test.go
+++ b/output/outputters/auto_paste_outputter_test.go
@@ -33,6 +33,28 @@ func TestAutoPasteOutputter_TypeToActiveWindow_NonASCIIUsesClipboardPaste(t *tes
 	}
 
 	args := readCapturedArgs(t, captureFile)
+	expected := []string{"key", "42:1", "110:1", "110:0", "42:0"}
+	if strings.Join(args, "\n") != strings.Join(expected, "\n") {
+		t.Fatalf("expected args %q, got %q", expected, args)
+	}
+}
+
+func TestAutoPasteOutputter_TypeToActiveWindow_NonASCIIUsesConfiguredPasteShortcut(t *testing.T) {
+	captureFile := installFakePasteTool(t)
+	typing := NewMockOutputter()
+	clipboard := NewMockOutputter()
+	cfg := &config.Config{}
+	cfg.Output.PasteShortcut = "ctrl+v"
+	cfg.Security.AllowedCommands = []string{"ydotool"}
+
+	outputter := NewAutoPasteOutputter(typing, clipboard, "ydotool", cfg).(*AutoPasteOutputter)
+	outputter.pasteDelay = 0
+
+	if err := outputter.TypeToActiveWindow("Привет"); err != nil {
+		t.Fatalf("expected configured paste shortcut to succeed, got %v", err)
+	}
+
+	args := readCapturedArgs(t, captureFile)
 	expected := []string{"key", "29:1", "47:1", "47:0", "29:0"}
 	if strings.Join(args, "\n") != strings.Join(expected, "\n") {
 		t.Fatalf("expected args %q, got %q", expected, args)

--- a/output/outputters/auto_paste_outputter_test.go
+++ b/output/outputters/auto_paste_outputter_test.go
@@ -39,28 +39,6 @@ func TestAutoPasteOutputter_TypeToActiveWindow_NonASCIIUsesClipboardPaste(t *tes
 	}
 }
 
-func TestAutoPasteOutputter_TypeToActiveWindow_NonASCIIUsesConfiguredPasteShortcut(t *testing.T) {
-	captureFile := installFakePasteTool(t)
-	typing := NewMockOutputter()
-	clipboard := NewMockOutputter()
-	cfg := &config.Config{}
-	cfg.Output.PasteShortcut = "ctrl+shift+v"
-	cfg.Security.AllowedCommands = []string{"ydotool"}
-
-	outputter := NewAutoPasteOutputter(typing, clipboard, "ydotool", cfg).(*AutoPasteOutputter)
-	outputter.pasteDelay = 0
-
-	if err := outputter.TypeToActiveWindow("Привет терминал"); err != nil {
-		t.Fatalf("expected configured paste shortcut to succeed, got %v", err)
-	}
-
-	args := readCapturedArgs(t, captureFile)
-	expected := []string{"key", "29:1", "42:1", "47:1", "47:0", "42:0", "29:0"}
-	if strings.Join(args, "\n") != strings.Join(expected, "\n") {
-		t.Fatalf("expected args %q, got %q", expected, args)
-	}
-}
-
 func TestAutoPasteOutputter_TypeToActiveWindow_ASCIIUsesTyping(t *testing.T) {
 	typing := NewMockOutputter()
 	clipboard := NewMockOutputter()

--- a/output/outputters/auto_paste_outputter_test.go
+++ b/output/outputters/auto_paste_outputter_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2025 Asher Buk
+// SPDX-License-Identifier: MIT
+
+package outputters
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/AshBuk/dabri/v2/config"
+)
+
+func TestAutoPasteOutputter_TypeToActiveWindow_NonASCIIUsesClipboardPaste(t *testing.T) {
+	captureFile := installFakePasteTool(t)
+	typing := NewMockOutputter()
+	clipboard := NewMockOutputter()
+	cfg := &config.Config{}
+	cfg.Security.AllowedCommands = []string{"ydotool"}
+
+	outputter := NewAutoPasteOutputter(typing, clipboard, "ydotool", cfg).(*AutoPasteOutputter)
+	outputter.pasteDelay = 0
+
+	if err := outputter.TypeToActiveWindow("Привет мир"); err != nil {
+		t.Fatalf("expected paste fallback to succeed, got %v", err)
+	}
+	if typing.WasTypeCalled() {
+		t.Fatal("expected typing backend not to be used for non-ASCII text")
+	}
+	if got := clipboard.GetLastClipboardCall(); got != "Привет мир" {
+		t.Fatalf("expected clipboard text %q, got %q", "Привет мир", got)
+	}
+
+	args := readCapturedArgs(t, captureFile)
+	expected := []string{"key", "29:1", "47:1", "47:0", "29:0"}
+	if strings.Join(args, "\n") != strings.Join(expected, "\n") {
+		t.Fatalf("expected args %q, got %q", expected, args)
+	}
+}
+
+func TestAutoPasteOutputter_TypeToActiveWindow_NonASCIIUsesConfiguredPasteShortcut(t *testing.T) {
+	captureFile := installFakePasteTool(t)
+	typing := NewMockOutputter()
+	clipboard := NewMockOutputter()
+	cfg := &config.Config{}
+	cfg.Output.PasteShortcut = "ctrl+shift+v"
+	cfg.Security.AllowedCommands = []string{"ydotool"}
+
+	outputter := NewAutoPasteOutputter(typing, clipboard, "ydotool", cfg).(*AutoPasteOutputter)
+	outputter.pasteDelay = 0
+
+	if err := outputter.TypeToActiveWindow("Привет терминал"); err != nil {
+		t.Fatalf("expected configured paste shortcut to succeed, got %v", err)
+	}
+
+	args := readCapturedArgs(t, captureFile)
+	expected := []string{"key", "29:1", "42:1", "47:1", "47:0", "42:0", "29:0"}
+	if strings.Join(args, "\n") != strings.Join(expected, "\n") {
+		t.Fatalf("expected args %q, got %q", expected, args)
+	}
+}
+
+func TestAutoPasteOutputter_TypeToActiveWindow_ASCIIUsesTyping(t *testing.T) {
+	typing := NewMockOutputter()
+	clipboard := NewMockOutputter()
+	cfg := &config.Config{}
+	cfg.Security.AllowedCommands = []string{"ydotool"}
+
+	outputter := NewAutoPasteOutputter(typing, clipboard, "ydotool", cfg)
+	if err := outputter.TypeToActiveWindow("hello world"); err != nil {
+		t.Fatalf("expected typing backend to succeed, got %v", err)
+	}
+	if got := typing.GetLastTypeCall(); got != "hello world" {
+		t.Fatalf("expected typed text %q, got %q", "hello world", got)
+	}
+	if clipboard.WasClipboardCalled() {
+		t.Fatal("expected clipboard backend not to be used for ASCII text")
+	}
+}
+
+func installFakePasteTool(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	captureFile := filepath.Join(dir, "args.txt")
+	script := filepath.Join(dir, "ydotool")
+	content := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$CAPTURE_FILE\"\n"
+	if err := os.WriteFile(script, []byte(content), 0700); err != nil {
+		t.Fatalf("write fake ydotool: %v", err)
+	}
+	t.Setenv("PATH", dir)
+	t.Setenv("CAPTURE_FILE", captureFile)
+	return captureFile
+}


### PR DESCRIPTION
  ## Summary
  - add a Wayland paste fallback for non-ASCII active-window output
  - use `wl-copy` plus `ydotool` paste shortcut when direct typing cannot handle Unicode
  - add configurable `output.paste_shortcut` for terminal paste behavior

  ## Testing
  - `docker compose run --rm dev go test ./output/outputters ./config/validators ./config/loaders ./output/factory`
  - tested manually on KDE Plasma 6 Wayland with Russian voice input into a terminal session
